### PR TITLE
Fix/missed types + typings for contatRight

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -303,8 +303,10 @@ declare namespace RamdaAdjunct {
         /**
          * Returns the result of concatenating the given lists or strings.
          */
-        concatRight<T extends Array<any>|string>(firstList: T, secondList: T): T;
-        concatRight<T extends Array<any>|string>(firstList: T): (secondList: T) => T;
+        concatRight<T extends Array<any>>(firstList: T, secondList: T): T;
+        concatRight<T extends Array<any>>(firstList: T): (secondList: T) => T;
+        concatRight(firstList: string, secondList: string): string;
+        concatRight(firstList: string): (secondList: string) => string;
 
         /**
          * Acts as multiple path: arrays of paths in, array of values out. Preserves order.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -304,6 +304,7 @@ declare namespace RamdaAdjunct {
          * Returns the result of concatenating the given lists or strings.
          */
         concatRight<T extends Array<any>|string>(firstList: T, secondList: T): T;
+        concatRight<T extends Array<any>|string>(firstList: T): (secondList: T) => T;
 
         /**
          * Acts as multiple path: arrays of paths in, array of values out. Preserves order.
@@ -316,6 +317,7 @@ declare namespace RamdaAdjunct {
          * the Apply spec of fantasy land.
          */
         liftFN<T>(arity: number, fn: Variadic<Apply<T>, T>): Apply<T>;
+        liftFN(arity: number): <T>(fn: Variadic<Apply<T>, T>) => Apply<T>;
 
         /**
          * "lifts" a function of arity > 1 so that it may "map over" objects that satisfy
@@ -543,6 +545,7 @@ declare namespace RamdaAdjunct {
          * Dispatches to the slice method of the third argument, if present.
          */
         sliceFrom<T>(fromIndex: number, list: string|Array<T>): string|Array<T>;
+        sliceFrom(fromIndex: number): <T>(list: string|Array<T>) => string|Array<T>;
 
         /**
          * Returns the elements of the given list or string (or object with a slice method)
@@ -550,6 +553,7 @@ declare namespace RamdaAdjunct {
          * Dispatches to the slice method of the second argument, if present.
          */
         sliceTo<T>(toIndex: number, list: string|Array<T>): string|Array<T>;
+        sliceTo(toIndex: number): <T>(list: string|Array<T>) => string|Array<T>;
 
          /**
          * Identity type.


### PR DESCRIPTION
also fixed this cases for `concatRight`

```ts
  // not right behavior 
  const add = RA.concatRight(':') // => (secondList:·":")·=>·":"
  const added = add('asdfasdf') // => ":"

  // right behavior 
  const add = RA.concatRight([1]) // => (secondList:·number[])·=>·number[]
  const added = add([2]) // => number[]

  // not right behavior 
  const added = RA.concatRight('asdf', 'we') // => "asdf" | "we"
```

now when parameter is string - string returned