### PR TITLE
build(npm) Remove module field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "type": "git",
     "url": "git://github.com/char0n/ramda-adjunct.git"
   },
-  "browser": "./es/index.js",
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "jsnext:main": "./es/index.js",


### PR DESCRIPTION
For the following reasons:

- The use of es6 esports in the referenced file caused an RTE in Webpack v1.x because it doesn’t transpile code from node modules.
- The use of the `browser` field in package.json was superfluous as it pointed to the same file as `module`. The purpose of the `browser` field is to provide code that is specific to a browser (for example it uses polyfills or shims), but that is not relevant for this lib at present. For spec of `browser` field see: https://github.com/defunctzombie/package-browser-field-spec

See: #242