### PR TITLE
Typo in docs

### DIFF
--- a/src/fantasy-land/Identity.js
+++ b/src/fantasy-land/Identity.js
@@ -122,7 +122,7 @@ class Identity {
    * const b = Identity.of(1);
    * const c = Identity.of(2);
    *
-   * a.equlas(b); //=> true
+   * a.equals(b); //=> true
    * a.equals(c); //=> false
    */
   [equals](setoid) {


### PR DESCRIPTION
Corrects a minor typo in the Identity equals documentation.