### PR TITLE
feat(api): add notBoth function

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "phantomjs": "=2.1.7",
     "ramda": "=0.25.0",
     "rimraf": "=2.6.2",
-    "sanctuary": "=0.14.1",
     "sinon": "4.1.3",
     "testem": "=1.18.4",
     "typescript": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "phantomjs": "=2.1.7",
     "ramda": "=0.25.0",
     "rimraf": "=2.6.2",
+    "sanctuary": "=0.14.1",
     "sinon": "4.1.3",
     "testem": "=1.18.4",
     "typescript": "2.6.2",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -663,11 +663,15 @@ declare namespace RamdaAdjunct {
           * A function which calls the two provided functions and returns the complement of `&&`ing
           * the results. It returns true if the first function is false-y and the complement of the
           * second function otherwise. Note that this is short-circuited, meaning that the second
-          * function will not be invoked if the first returns a false-y value.
-         */
+          * function will not be invoked if the first returns a false-y value. In short it will
+          * return true unless both predicates return true.
+          *
+          * In addition to functions, `RA.notBoth` also accepts any fantasy-land compatible
+          * applicative functor.
+          */
         notBoth(firstPredicate: Function, secondPredicate: Function): Function;
 
-         /**
+        /**
          * Identity type.
          */
         Identity: Function;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -660,6 +660,14 @@ declare namespace RamdaAdjunct {
         defaultWhen(predicate: Function): <DefVal, Val>(defaultVal: DefVal) => (val: Val) => DefVal | Val;
 
          /**
+          * A function which calls the two provided functions and returns the complement of `&&`ing
+          * the results. It returns true if the first function is false-y and the complement of the
+          * second function otherwise. Note that this is short-circuited, meaning that the second
+          * function will not be invoked if the first returns a false-y value.
+         */
+        notBoth(firstPredicate: Function, secondPredicate: Function): Function;
+
+         /**
          * Identity type.
          */
         Identity: Function;

--- a/src/index.js
+++ b/src/index.js
@@ -113,5 +113,6 @@ export { default as lensNotSatisfy } from './lensNotSatisfy';
 export { default as lensIso } from './lensIso';
 // Logic
 export { default as defaultWhen } from './defaultWhen';
+export { default as notBoth } from './notBoth';
 // Types
 export { default as Identity } from './fantasy-land/Identity';

--- a/src/notBoth.js
+++ b/src/notBoth.js
@@ -1,5 +1,7 @@
 import { compose, complement, both } from 'ramda';
 
+
+/* eslint-disable max-len */
 /**
  * A function which calls the two provided functions and returns the complement of `&&`ing the
  * results.
@@ -14,22 +16,23 @@ import { compose, complement, both } from 'ramda';
  * @func notBoth
  * @memberOf RA
  * @since {@link https://char0n.github.io/ramda-adjunct/2.3.0|v2.3.0}
- * @category Type
+ * @category Logic
  * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
  * @param {Function} f A predicate
  * @param {Function} g Another predicate
- * @return {Function} a function that applies its arguments to `f` and `g` and returns the
- * complement of `&&`ing their outputs together.
+ * @return {Function} Returns a function that applies its arguments to `f` and `g` and returns the complement of `&&`ing their outputs together.
  * @example
  *
  * const gt10 = R.gt(R.__, 10)
  * const even = (x) => x % 2 === 0;
  * const f = RA.notBoth(gt10, even);
+ *
  * f(12); //=> false
  * f(8); //=> true
  * f(11); //=> true
  * f(9); //=> true
  */
-const _notBoth = compose(complement, both);
+/* eslint-enable max-len */
+const notBoth = compose(complement, both);
 
-export default _notBoth;
+export default notBoth;

--- a/src/notBoth.js
+++ b/src/notBoth.js
@@ -1,0 +1,35 @@
+import { compose, complement, both } from 'ramda';
+
+/**
+ * A function which calls the two provided functions and returns the complement of `&&`ing the
+ * results.
+ * It returns true if the first function is false-y and the complement of the second function
+ * otherwise. Note that this is short-circuited, meaning that the second function will not be
+ * invoked if the first returns a false-y value. In short it will return true unless both predicates
+ * return true.
+ *
+ * In addition to functions, `RA.notBoth` also accepts any fantasy-land compatible
+ * applicative functor.
+ *
+ * @func notBoth
+ * @memberOf RA
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.3.0|v2.3.0}
+ * @category Type
+ * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
+ * @param {Function} f A predicate
+ * @param {Function} g Another predicate
+ * @return {Function} a function that applies its arguments to `f` and `g` and returns the
+ * complement of `&&`ing their outputs together.
+ * @example
+ *
+ * const gt10 = R.gt(R.__, 10)
+ * const even = (x) => x % 2 === 0;
+ * const f = RA.notBoth(gt10, even);
+ * f(12); //=> false
+ * f(8); //=> true
+ * f(11); //=> true
+ * f(9); //=> true
+ */
+const _notBoth = compose(complement, both);
+
+export default _notBoth;

--- a/src/notBoth.js
+++ b/src/notBoth.js
@@ -21,6 +21,7 @@ import { compose, complement, both } from 'ramda';
  * @param {Function} f A predicate
  * @param {Function} g Another predicate
  * @return {Function} Returns a function that applies its arguments to `f` and `g` and returns the complement of `&&`ing their outputs together.
+ * @see {@link http://ramdajs.com/docs/#both|both}
  * @example
  *
  * const gt10 = R.gt(R.__, 10)

--- a/test/notBoth.js
+++ b/test/notBoth.js
@@ -6,18 +6,18 @@ import eq from './shared/eq';
 
 
 const supportsFantasyLand = () => {
-  let result;
-  // Earlier versions of Ramda will throw.
   try {
-    result = RA.notBoth(Just(true), Just(true));
+    return RA.notBoth(Just(true), Just(true)).equals(Just(false));
   } catch (e) {
     return false;
   }
-  return Just(false).equals(result);
 };
 
 describe('notBoth', function() {
-  const isFantasyLandSupported = supportsFantasyLand();
+  let isFantasyLandSupported;
+  before(function() {
+    isFantasyLandSupported = supportsFantasyLand();
+  });
 
   it('combines two boolean-returning functions into one', function() {
     const even = x => x % 2 === 0;

--- a/test/notBoth.js
+++ b/test/notBoth.js
@@ -1,0 +1,47 @@
+import S from 'sanctuary';
+
+import * as RA from '../src/index';
+import eq from './shared/eq';
+
+describe('notBoth', function() {
+  it('combines two boolean-returning functions into one', function() {
+    const even = function(x) { return x % 2 === 0 };
+    const gt10 = function(x) { return x > 10 };
+    const f = RA.notBoth(even, gt10);
+    eq(f(8), true);
+    eq(f(13), true);
+    eq(f(9), true);
+    eq(f(14), false);
+  });
+
+  it('accepts functions that take multiple parameters', function() {
+    const between = function(a, b, c) { return a < b && b < c };
+    const total20 = function(a, b, c) { return a + b + c === 20 };
+    const f = RA.notBoth(between, total20);
+    eq(f(4, 5, 11), false);
+    eq(f(12, 2, 7), true);
+    eq(f(12, 2, 6), true);
+    eq(f(5, 6, 15), true);
+  });
+
+  it('does not evaluate the second expression if the first one is false', function() {
+    let effect = 'not evaluated';
+    const F = function() { return false };
+    const Z = function() { effect = 'Z got evaluated' };
+    RA.notBoth(F, Z)();
+    eq(effect, 'not evaluated');
+  });
+
+  it('accepts fantasy-land applicative functors', function() {
+    const { Just, Nothing } = S;
+    eq(RA.notBoth(Just(true), Just(true)), Just(false));
+    eq(RA.notBoth(Just(true), Just(false)), Just(true));
+    eq(RA.notBoth(Just(false), Just(true)), Just(true));
+    eq(RA.notBoth(Just(false), Just(false)), Just(true));
+    eq(RA.notBoth(Just(true), Nothing), Nothing);
+    eq(RA.notBoth(Nothing, Just(true)), Nothing);
+    eq(RA.notBoth(Nothing, Just(false)), Nothing);
+    eq(RA.notBoth(Just(false), Nothing), Nothing);
+    eq(RA.notBoth(Nothing, Nothing), Nothing);
+  });
+});

--- a/test/notBoth.js
+++ b/test/notBoth.js
@@ -1,13 +1,16 @@
-import S from 'sanctuary';
+import { Just, Nothing } from 'monet';
+import sinon from 'sinon';
 
 import * as RA from '../src/index';
 import eq from './shared/eq';
 
+
 describe('notBoth', function() {
   it('combines two boolean-returning functions into one', function() {
-    const even = function(x) { return x % 2 === 0 };
-    const gt10 = function(x) { return x > 10 };
+    const even = x => x % 2 === 0;
+    const gt10 = x => x > 10;
     const f = RA.notBoth(even, gt10);
+
     eq(f(8), true);
     eq(f(13), true);
     eq(f(9), true);
@@ -15,9 +18,10 @@ describe('notBoth', function() {
   });
 
   it('accepts functions that take multiple parameters', function() {
-    const between = function(a, b, c) { return a < b && b < c };
-    const total20 = function(a, b, c) { return a + b + c === 20 };
+    const between = (a, b, c) => a < b && b < c;
+    const total20 = (a, b, c) => a + b + c === 20;
     const f = RA.notBoth(between, total20);
+
     eq(f(4, 5, 11), false);
     eq(f(12, 2, 7), true);
     eq(f(12, 2, 6), true);
@@ -25,23 +29,22 @@ describe('notBoth', function() {
   });
 
   it('does not evaluate the second expression if the first one is false', function() {
-    let effect = 'not evaluated';
-    const F = function() { return false };
-    const Z = function() { effect = 'Z got evaluated' };
-    RA.notBoth(F, Z)();
-    eq(effect, 'not evaluated');
+    const f = () => false;
+    const z = sinon.spy();
+
+    RA.notBoth(f, z)();
+    eq(z.notCalled, true);
   });
 
   it('accepts fantasy-land applicative functors', function() {
-    const { Just, Nothing } = S;
     eq(RA.notBoth(Just(true), Just(true)), Just(false));
     eq(RA.notBoth(Just(true), Just(false)), Just(true));
     eq(RA.notBoth(Just(false), Just(true)), Just(true));
     eq(RA.notBoth(Just(false), Just(false)), Just(true));
-    eq(RA.notBoth(Just(true), Nothing), Nothing);
-    eq(RA.notBoth(Nothing, Just(true)), Nothing);
-    eq(RA.notBoth(Nothing, Just(false)), Nothing);
-    eq(RA.notBoth(Just(false), Nothing), Nothing);
-    eq(RA.notBoth(Nothing, Nothing), Nothing);
+    eq(RA.notBoth(Just(true), Nothing()), Nothing());
+    eq(RA.notBoth(Nothing(), Just(true)), Nothing());
+    eq(RA.notBoth(Nothing(), Just(false)), Nothing());
+    eq(RA.notBoth(Just(false), Nothing()), Nothing());
+    eq(RA.notBoth(Nothing(), Nothing()), Nothing());
   });
 });

--- a/test/notBoth.js
+++ b/test/notBoth.js
@@ -5,7 +5,20 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 
+const supportsFantasyLand = () => {
+  let result;
+  // Earlier versions of Ramda will throw.
+  try {
+    result = RA.notBoth(Just(true), Just(true));
+  } catch (e) {
+    return false;
+  }
+  return Just(false).equals(result);
+};
+
 describe('notBoth', function() {
+  const isFantasyLandSupported = supportsFantasyLand();
+
   it('combines two boolean-returning functions into one', function() {
     const even = x => x % 2 === 0;
     const gt10 = x => x > 10;
@@ -36,15 +49,17 @@ describe('notBoth', function() {
     eq(z.notCalled, true);
   });
 
-  it('accepts fantasy-land applicative functors', function() {
-    eq(RA.notBoth(Just(true), Just(true)), Just(false));
-    eq(RA.notBoth(Just(true), Just(false)), Just(true));
-    eq(RA.notBoth(Just(false), Just(true)), Just(true));
-    eq(RA.notBoth(Just(false), Just(false)), Just(true));
-    eq(RA.notBoth(Just(true), Nothing()), Nothing());
-    eq(RA.notBoth(Nothing(), Just(true)), Nothing());
-    eq(RA.notBoth(Nothing(), Just(false)), Nothing());
-    eq(RA.notBoth(Just(false), Nothing()), Nothing());
-    eq(RA.notBoth(Nothing(), Nothing()), Nothing());
-  });
+  if (isFantasyLandSupported) {
+    it('accepts fantasy-land applicative functors', function() {
+      eq(RA.notBoth(Just(true), Just(true)), Just(false));
+      eq(RA.notBoth(Just(true), Just(false)), Just(true));
+      eq(RA.notBoth(Just(false), Just(true)), Just(true));
+      eq(RA.notBoth(Just(false), Just(false)), Just(true));
+      eq(RA.notBoth(Just(true), Nothing()), Nothing());
+      eq(RA.notBoth(Nothing(), Just(true)), Nothing());
+      eq(RA.notBoth(Nothing(), Just(false)), Nothing());
+      eq(RA.notBoth(Just(false), Nothing()), Nothing());
+      eq(RA.notBoth(Nothing(), Nothing()), Nothing());
+    });
+  }
 });


### PR DESCRIPTION
Add `notBoth` function which is complement of Ramda's `both`.

- I've kept the docs close to Ramda's docs for `both`.
- I've assumed the next release will be 2.3.0.
- I've had to add Sanctuary as a dev dependency to replicate the fantasy-land tests.
- I'll add the other complements in separate PRs once this one is approved.

Ref #234