### PR TITLE
chore(scripts): improve prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:umd": "webpack --config webpack.config.js",
     "nsp:check": "nsp check",
-    "prepublishOnly": "npm run clean && npm run lint && npm run test && npm run build",
+    "prepublishOnly": "npm run clean && npm run lint && npm run test && npm run test:web && npm run build",
     "clean": "rimraf .nyc_output .tmp docs coverage tmp-test-bundle.js dist lib es"
   },
   "readme": "README.md",


### PR DESCRIPTION
This script is useful before a push.

-----------

Every time I push, I like to check if all is good using : 
```bash
$ npm run clean && npm run lint && npm run test && npm run test:web && npm run build
```

What do you think about a `test:all` npm script ?