### PR TITLE
feat(notAllPass): Add notAllPass which is the complement of allPass

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -764,6 +764,16 @@ declare namespace RamdaAdjunct {
           */
           neither(firstPredicate: Function, secondPredicate: Function): Function;
 
+         /**
+          * Takes a list of predicates and returns a predicate that returns true for a given list of
+          * arguments if one or more of the provided predicates is not satisfied by those arguments.
+          * It is the complement of Ramda's allPass.
+          * 
+          * The function returned is a curried function whose arity matches that of the
+          * highest-arity predicate.
+          */
+        notAllPass(predicates: Array<Function>): Function;
+
         /**
          * Identity type.
          */

--- a/src/index.js
+++ b/src/index.js
@@ -125,5 +125,6 @@ export { default as isNotEmpty } from './isNotEmpty';
 export { default as defaultWhen } from './defaultWhen';
 export { default as notBoth } from './notBoth';
 export { default as neither } from './neither';
+export { default as notAllPass } from './notAllPass';
 // Types
 export { default as Identity } from './fantasy-land/Identity';

--- a/src/notAllPass.js
+++ b/src/notAllPass.js
@@ -1,4 +1,4 @@
-import { curry, curryN, reduce, pluck, max } from 'ramda';
+import { complement, compose, allPass } from 'ramda';
 
 
 /**
@@ -28,16 +28,6 @@ import { curry, curryN, reduce, pluck, max } from 'ramda';
  * f(11); //=> true
  * f(9); //=> true
  */
-const notAllPass = curry(preds => curryN(reduce(max, 0, pluck('length', preds)), function testPredicates(...args) {
-  let idx = 0;
-  const len = preds.length;
-  while (idx < len) {
-    if (!preds[idx].apply(this, args)) {
-      return true;
-    }
-    idx += 1;
-  }
-  return false;
-}));
+const notAllPass = compose(complement, allPass);
 
 export default notAllPass;

--- a/src/notAllPass.js
+++ b/src/notAllPass.js
@@ -1,0 +1,43 @@
+import { curry, curryN, reduce, pluck, max } from 'ramda';
+
+
+/**
+ * Takes a list of predicates and returns a predicate that returns true for a given list of
+ * arguments if one or more of the provided predicates is not satisfied by those arguments. It is
+ * the complement of Ramda's allPass.
+ *
+ * The function returned is a curried function whose arity matches that of the
+ * highest-arity predicate.
+ *
+ * @func notAllPass
+ * @memberOf RA
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.4.0|v2.4.0}
+ * @category Logic
+ * @sig [(*... -> Boolean)] -> (*... -> Boolean)
+ * @param {Array} predicates An array of predicates to check
+ * @return {Function} The combined predicate
+ * @see {@link http://ramdajs.com/docs/#allPass|allPass}
+ * @example
+ *
+ * const gt10 = R.gt(R.__, 10)
+ * const even = (x) => x % 2 === 0;
+ * const f = RA.notAllPass([gt10, even]);
+ *
+ * f(12); //=> false
+ * f(8); //=> true
+ * f(11); //=> true
+ * f(9); //=> true
+ */
+const notAllPass = curry(preds => curryN(reduce(max, 0, pluck('length', preds)), function testPredicates(...args) {
+  let idx = 0;
+  const len = preds.length;
+  while (idx < len) {
+    if (!preds[idx].apply(this, args)) {
+      return true;
+    }
+    idx += 1;
+  }
+  return false;
+}));
+
+export default notAllPass;

--- a/test/notAllPass.js
+++ b/test/notAllPass.js
@@ -2,13 +2,13 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 
-describe('allPass', () => {
+describe('allPass', function () {
   const odd = n => n % 2 !== 0;
   const lt20 = n => n < 20;
   const gt5 = n => n > 5;
   const plusEq = (w, x, y, z) => w + x === y + z;
 
-  it('reports whether all predicates are satisfied by a given value', () => {
+  it('reports whether all predicates are satisfied by a given value', function () {
     const ok = RA.notAllPass([odd, lt20, gt5]);
     eq(ok(7), false); // all ps succeed
     eq(ok(10), true); // p1 fails
@@ -18,11 +18,11 @@ describe('allPass', () => {
     eq(ok(4), true); // p1 and p3 fails
   });
 
-  it('returns false on empty predicate list', () => {
+  it('returns false on empty predicate list', function () {
     eq(RA.notAllPass([])(3), false);
   });
 
-  it('returns a curried function whose arity matches that of the highest-arity predicate', () => {
+  it('returns a curried function whose arity matches that of the highest-arity predicate', function () {
     eq(RA.notAllPass([odd, gt5, plusEq]).length, 4);
     eq(RA.notAllPass([odd, gt5, plusEq])(9, 9, 9, 10), true);
     eq(RA.notAllPass([odd, gt5, plusEq])(9)(9)(9)(10), true);

--- a/test/notAllPass.js
+++ b/test/notAllPass.js
@@ -1,0 +1,30 @@
+import * as RA from '../src/index';
+import eq from './shared/eq';
+
+
+describe('allPass', () => {
+  const odd = n => n % 2 !== 0;
+  const lt20 = n => n < 20;
+  const gt5 = n => n > 5;
+  const plusEq = (w, x, y, z) => w + x === y + z;
+
+  it('reports whether all predicates are satisfied by a given value', () => {
+    const ok = RA.notAllPass([odd, lt20, gt5]);
+    eq(ok(7), false); // all ps succeed
+    eq(ok(10), true); // p1 fails
+    eq(ok(21), true); // p2 fails
+    eq(ok(3), true); // p3 fails
+    eq(ok(22), true); // p1 and p2 fails
+    eq(ok(4), true); // p1 and p3 fails
+  });
+
+  it('returns false on empty predicate list', () => {
+    eq(RA.notAllPass([])(3), false);
+  });
+
+  it('returns a curried function whose arity matches that of the highest-arity predicate', () => {
+    eq(RA.notAllPass([odd, gt5, plusEq]).length, 4);
+    eq(RA.notAllPass([odd, gt5, plusEq])(9, 9, 9, 10), true);
+    eq(RA.notAllPass([odd, gt5, plusEq])(9)(9)(9)(10), true);
+  });
+});


### PR DESCRIPTION
Because of the auto-currying I had to use Ramda's implementation of `allPass`, but tweaked to return the correct result and to satisfy eslint.

Ref #234
