### PR TITLE
test(prettier): add scripts/prettier-test.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   },
   "betterScripts": {
     "docs": "jsdoc -c jsdoc.json && node ./scripts/jsdoc-inject-dist.js",
-    "lint": "prettier test/**.js src/**.js --write && eslint ./ && tslint -c tslint.json src/index.d.ts",
+    "lint": "./scripts/prettier-test.sh && eslint ./ && tslint -c tslint.json src/index.d.ts",
+    "lint:fix": "prettier test/**.js src/**.js --write",
     "changelog": "conventional-changelog -p angular -i ./CHANGELOG.md -s",
     "test": "cross-env BABEL_ENV=commonjs mocha",
     "test:web": "testem ci",

--- a/scripts/prettier-test.sh
+++ b/scripts/prettier-test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PRETTIER=./node_modules/.bin/prettier
+INPUT_FILES="./src/**.js ./test/**.js"
+
+$PRETTIER $INPUT_FILES --list-different
+
+if [ "$?" != "0" ] ; then
+  echo "Prettier: this files need to be fixed (use npm run lint:fix)"
+  exit 1
+fi
+


### PR DESCRIPTION
- move prettier from `lint` to `lint:fix` npm script
- run `prettier-test.sh` in `lint` npm script

Ref #379, #336