### PR TITLE
WIP: Git hooks

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node": ">=0.10.3"
   },
   "scripts": {
+    "prepush": "bnr lint && bnr test && bnr build && bnr docs",
     "docs": "better-npm-run docs",
     "lint": "better-npm-run lint",
     "lint:fix": "better-npm-run lint:fix",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node": ">=0.10.3"
   },
   "scripts": {
+    "precommit": "bash scripts/pre-commit.sh",
     "prepush": "bnr lint && bnr test && bnr build && bnr docs",
     "docs": "better-npm-run docs",
     "lint": "better-npm-run lint",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "eslint-plugin-ramda": "=2.4.0",
     "fantasy-land": "3.5.0",
     "glob": "=7.1.2",
+    "husky": "=0.14.3",
     "istanbul": "=0.4.5",
     "jsdoc": "=3.5.5",
     "jsverify": "=0.8.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "scripts": {
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "precommit": "bash scripts/pre-commit.sh",
-    "prepush": "bnr lint && bnr test && bnr build && bnr docs",
     "docs": "better-npm-run docs",
     "lint": "better-npm-run lint",
     "lint:fix": "better-npm-run lint:fix",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node": ">=0.10.3"
   },
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "precommit": "bash scripts/pre-commit.sh",
     "prepush": "bnr lint && bnr test && bnr build && bnr docs",
     "docs": "better-npm-run docs",
@@ -97,6 +98,8 @@
     "ramda": ">= 0.19.0 <= 0.25.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "=6.1.0",
+    "@commitlint/config-conventional": "=6.1.0",
     "babel-cli": "=6.26.0",
     "babel-core": "=6.26.0",
     "babel-loader": "=7.1.2",

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+for file in $(git diff --cached --name-only --diff-filter=ACM "*.js")
+do
+  # we only want to lint the staged changes, not any un-staged changes
+  git show ":$file" | node_modules/.bin/eslint --stdin --stdin-filename "$file"
+  if [ $? -ne 0 ]; then
+    echo "ESLint failed on staged file '$file'. Please check your code and try again. You can run ESLint manually via npm run lint."
+    exit 1 # exit with failure status
+  fi
+done


### PR DESCRIPTION
Resolves #381.
Resolves #386.

All the hooks we discussed, everything I came up with.

Every hook is added in a separate commit, so to not add a hook, just reverting a commit.

I suggest merge-squashing it after we're done, one `chore(package): added git hooks` would be completely fine IMO.

~~I think that push hook unnecessarily builds the project twice, one for testing, one for build. If that's the case, then `bnr build` in `prepush` is just wasting time. (It is there in the first place because of https://github.com/char0n/ramda-adjunct/issues/381#issuecomment-366826618)~~
`npm run build` creates 3 builds. Trying to build just one just to see if it succeeds would probably suffice on pre-push, especially when all of the builds are created on `prepublishOnly`.

~~I had trouble pushing this, I think they were network issues (When I tried to push from the terminal, I had nothing for a while, they it asked me about credentials, and then either said that they were invalid, or said something about http error), but still, I think it's a good idea that you know it, after all, I added `prepush` hook.~~ I'm getting similar errors without the hook... maybe I should just install Linux on my main machine, things wouldn't spontaneously break for no reason.

Haven't put the scripts in `betterScripts` for the simple reason of avoiding running additional program, `bnr`.