### PR TITLE
feat: updateSlice

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -765,6 +765,31 @@ declare namespace RamdaAdjunct {
         sliceTo<T>(toIndex: number, list: string|T[]): string|T[];
         sliceTo(toIndex: number): <T>(list: string|T[]) => string|T[];
 
+        updateSlice(fromIndex: number, toIndex: number, replacement: string, list: string): string;
+        updateSlice(fromIndex: number, toIndex: number, replacement: string): (list: string) => string;
+        updateSlice(fromIndex: number, toIndex: number): {
+            (replacement: string): (list: string) => string;
+            (replacement: string, list: string): string;
+        }
+        updateSlice(fromIndex: number): {
+            (toIndex: number): (replacement: string) => (list: string) => string;
+            (toIndex: number): (replacement: string, list: string) => string;
+            (toIndex: number, replacement: string): (list: string) => string;
+            (toIndex: number, replacement: string, list: string): string;
+        }
+        updateSlice<T>(fromIndex: number, toIndex: number, replacement: T[], list: T[]): T[];
+        updateSlice<T>(fromIndex: number, toIndex: number, replacement: T[]): (list: T[]) => T[];
+        updateSlice<T>(fromIndex: number, toIndex: number): {
+            (replacement: T[]): (list: T[]) => T[];
+            (replacement: T[], list: T[]): T[];
+        }
+        updateSlice<T>(fromIndex: number): {
+            (toIndex: number): (replacement: T[]) => (list: T[]) => T[];
+            (toIndex: number): (replacement: T[], list: T[]) => T[];
+            (toIndex: number, replacement: T[]): (list: T[]) => T[];
+            (toIndex: number, replacement: T[], list: T[]): T[];
+        }
+
         /**
          * Returns a partial copy of an array omitting the indexes specified.
          */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -765,6 +765,14 @@ declare namespace RamdaAdjunct {
         sliceTo<T>(toIndex: number, list: string|T[]): string|T[];
         sliceTo(toIndex: number): <T>(list: string|T[]) => string|T[];
 
+        /**
+         * Returns a new copy of the list or string
+         * with slice from fromIndex (inclusive) to toIndex (exclusive)
+         * replaced by the provided value.
+         *
+         * If toIndex is lower then fromIndex,
+         * then the behavior of the updateSlice is unspecified.
+         */
         updateSlice(fromIndex: number, toIndex: number, replacement: string, list: string): string;
         updateSlice(fromIndex: number, toIndex: number, replacement: string): (list: string) => string;
         updateSlice(fromIndex: number, toIndex: number): {

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ export { default as reduceP } from './reduceP';
 export { default as reduceRightP } from './reduceRightP';
 export { default as sliceFrom } from './sliceFrom';
 export { default as sliceTo } from './sliceTo';
+export { default as updateSlice } from './updateSlice';
 export { default as omitIndexes } from './omitIndexes';
 export { default as compact } from './compact';
 export { default as appendFlipped } from './appendFlipped';

--- a/src/updateSlice.js
+++ b/src/updateSlice.js
@@ -9,6 +9,9 @@ import sliceTo from './sliceTo';
  * with slice from fromIndex (inclusive) to toIndex (exclusive)
  * replaced by the provided value.
  *
+ * If toIndex is lower then fromIndex,
+ * then the behavior of the updateSlice is unspecified.
+ *
  * @func updateSlice
  * @memberOf RA
  * @category List
@@ -25,7 +28,6 @@ import sliceTo from './sliceTo';
  * RA.updateSlice(1, 3, 'DDDD', 'ABBCCC'); //=> 'ADDDDCCC'
  * RA.updateSlice(1, 3, Array.from('DDDD'), Array.from('ABBCCC')); //=> [ 'A', 'D', 'D', 'D', 'D', 'C', 'C', 'C' ]
  * RA.updateSlice(-5, -3, 'DDDD', 'ABBCCC'); //=> 'ADDDDCCC'
- * RA.updateSlice(3, 1, 'DDDD', 'ABBCCC'); //=> 'ABBDDDDBBCCC'
  */
 const updateSlice = curry((fromIndex, toIndex, replacement, list) =>
   concatAll([sliceTo(fromIndex, list), replacement, sliceFrom(toIndex, list)])

--- a/src/updateSlice.js
+++ b/src/updateSlice.js
@@ -5,31 +5,30 @@ import sliceFrom from './sliceFrom';
 import sliceTo from './sliceTo';
 
 /**
- * Returns target with given slice replaced using passed replacement.
+ * Returns a new copy of the list or string
+ * with slice from fromIndex (inclusive) to toIndex (exclusive)
+ * replaced by the provided value.
  *
  * @func updateSlice
  * @memberOf RA
  * @category List
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.7.0|v2.7.0}
  * @sig Number -> Number -> [a] -> [a] -> [a]
  * @sig Number -> Number -> String -> String -> String
  * @param {number} fromIndex
  * @param {number} toIndex
- * @param {string|any[]} replacement
- * @param {string|any[]} target
- * @returns {string|any[]} target with given slice replaced using passed replacement
+ * @param {string|Array} replacement
+ * @param {string|Array} list
+ * @returns {string|Array} list with given slice replaced using passed replacement
  * @example
  *
- * RA.updateSlice(1, 3, 'DDDD', 'ABBCCC') //=> 'ADDDDCCC'
- * RA.updateSlice(1, 3, Array.from('DDDD'), Array.from('ABBCCC')) //=> [ 'A', 'D', 'D', 'D', 'D', 'C', 'C', 'C' ]
- * RA.updateSlice(-5, -3, 'DDDD', 'ABBCCC') //=> 'ADDDDCCC'
- * RA.updateSlice(3, 1, 'DDDD', 'ABBCCC') //=> 'ABBDDDDBBCCC'
+ * RA.updateSlice(1, 3, 'DDDD', 'ABBCCC'); //=> 'ADDDDCCC'
+ * RA.updateSlice(1, 3, Array.from('DDDD'), Array.from('ABBCCC')); //=> [ 'A', 'D', 'D', 'D', 'D', 'C', 'C', 'C' ]
+ * RA.updateSlice(-5, -3, 'DDDD', 'ABBCCC'); //=> 'ADDDDCCC'
+ * RA.updateSlice(3, 1, 'DDDD', 'ABBCCC'); //=> 'ABBDDDDBBCCC'
  */
-const updateSlice = curry((fromIndex, toIndex, replacement, target) =>
-  concatAll([
-    sliceTo(fromIndex, target),
-    replacement,
-    sliceFrom(toIndex, target),
-  ])
+const updateSlice = curry((fromIndex, toIndex, replacement, list) =>
+  concatAll([sliceTo(fromIndex, list), replacement, sliceFrom(toIndex, list)])
 );
 
 export default updateSlice;

--- a/src/updateSlice.js
+++ b/src/updateSlice.js
@@ -1,0 +1,35 @@
+import { curry } from 'ramda';
+
+import concatAll from './concatAll';
+import sliceFrom from './sliceFrom';
+import sliceTo from './sliceTo';
+
+/**
+ * Returns target with given slice replaced using passed replacement.
+ *
+ * @func updateSlice
+ * @memberOf RA
+ * @category List
+ * @sig Number -> Number -> [a] -> [a] -> [a]
+ * @sig Number -> Number -> String -> String -> String
+ * @param {number} fromIndex
+ * @param {number} toIndex
+ * @param {string|any[]} replacement
+ * @param {string|any[]} target
+ * @returns {string|any[]} target with given slice replaced using passed replacement
+ * @example
+ *
+ * RA.updateSlice(1, 3, 'DDDD', 'ABBCCC') //=> 'ADDDDCCC'
+ * RA.updateSlice(1, 3, Array.from('DDDD'), Array.from('ABBCCC')) //=> [ 'A', 'D', 'D', 'D', 'D', 'C', 'C', 'C' ]
+ * RA.updateSlice(-5, -3, 'DDDD', 'ABBCCC') //=> 'ADDDDCCC'
+ * RA.updateSlice(3, 1, 'DDDD', 'ABBCCC') //=> 'ABBDDDDBBCCC'
+ */
+const updateSlice = curry((fromIndex, toIndex, replacement, target) =>
+  concatAll([
+    sliceTo(fromIndex, target),
+    replacement,
+    sliceFrom(toIndex, target),
+  ])
+);
+
+export default updateSlice;

--- a/test/updateSlice.js
+++ b/test/updateSlice.js
@@ -13,4 +13,14 @@ describe('updateSlice', function() {
   it('should support negative indexes', function() {
     eq(RA.updateSlice(-5, -3, 'DDDD', 'ABBCCC'), 'ADDDDCCC');
   });
+
+  it('is curried', function() {
+    eq(RA.updateSlice(1, 3, 'DDDD')('ABBCCC'), 'ADDDDCCC');
+    eq(RA.updateSlice(1, 3)('DDDD', 'ABBCCC'), 'ADDDDCCC');
+    eq(RA.updateSlice(1, 3)('DDDD')('ABBCCC'), 'ADDDDCCC');
+    eq(RA.updateSlice(1)(3, 'DDDD', 'ABBCCC'), 'ADDDDCCC');
+    eq(RA.updateSlice(1)(3, 'DDDD')('ABBCCC'), 'ADDDDCCC');
+    eq(RA.updateSlice(1)(3)('DDDD', 'ABBCCC'), 'ADDDDCCC');
+    eq(RA.updateSlice(1)(3)('DDDD')('ABBCCC'), 'ADDDDCCC');
+  });
 });

--- a/test/updateSlice.js
+++ b/test/updateSlice.js
@@ -7,10 +7,7 @@ describe('updateSlice', function() {
   });
 
   it('should work on arrays', function() {
-    eq(
-      RA.updateSlice(1, 3, Array.from('DDDD'), Array.from('ABBCCC')),
-      Array.from('ADDDDCCC')
-    );
+    eq(RA.updateSlice(1, 3, [4, 4, 4, 4], [1, 2, 2, 3]), [1, 4, 4, 4, 4, 3]);
   });
 
   it('should support negative indexes', function() {

--- a/test/updateSlice.js
+++ b/test/updateSlice.js
@@ -1,0 +1,19 @@
+import * as RA from '../src';
+import eq from './shared/eq';
+
+describe('updateSlice', function() {
+  it('should work on strings', function() {
+    eq(RA.updateSlice(1, 3, 'DDDD', 'ABBCCC'), 'ADDDDCCC');
+  });
+
+  it('should work on arrays', function() {
+    eq(
+      RA.updateSlice(1, 3, Array.from('DDDD'), Array.from('ABBCCC')),
+      Array.from('ADDDDCCC')
+    );
+  });
+
+  it('should support negative indexes', function() {
+    eq(RA.updateSlice(-5, -3, 'DDDD', 'ABBCCC'), 'ADDDDCCC');
+  });
+});


### PR DESCRIPTION
I'd ask someone else to write typings. When I tried to do something like (simplified): `<S extends string|any[]>(replacement: S, target: S): S`, when I passed string literals `"a"` and `"s"`, it inferred `S` to be `"a" | "s"` ._.

We could also consider extending the function to work on and return "Slice-able" (which'd extend Semigroup), but there's no such thing in Fantasy Land, hence I didn't go for it.

What should we do in case `fromIndex > toIndex`? I'd say, either do the current thing, let it do whatever it pleases (consistent with `R.slice`), or throw, because it was probably a mistake (consistent with `R.clamp`).

This function wasn't discussed before (it was born in https://github.com/char0n/ramda-adjunct/issues/395#issuecomment-367297854), so feel free to raise any concerns and toss any ideas here.