### PR TITLE
ci(codeclimate): disable eslint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,7 +9,7 @@ engines:
       languages:
       - javascript
   eslint:
-    enabled: true
+    enabled: false
     channel: "eslint-4"
     checks:
           import/extensions:


### PR DESCRIPTION
We are already running eslint via CircleCI so no need to run in Code Climate as well.