### PR TITLE
chore(commitlint): camel or kebab case for scope

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,15 @@
 {
-  "extends": ["@commitlint/config-conventional"],
+  "extends": [
+    "@commitlint/config-conventional"
+  ],
   "rules": {
-    "scope-case": [0]
+    "scope-case": [
+      2,
+      "always",
+      [
+        "camel-case",
+        "kebab-case"
+      ]
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   },
   "devDependencies": {
     "@commitlint/config-conventional": "=6.1.0",
+    "@commitlint/cli": "=6.2.0",
     "babel-cli": "=6.26.0",
     "babel-core": "=6.26.0",
     "babel-loader": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "ramda": ">= 0.19.0 <= 0.25.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "6.1.3",
     "@commitlint/config-conventional": "=6.1.0",
     "babel-cli": "=6.26.0",
     "babel-core": "=6.26.0",


### PR DESCRIPTION
commitlint now supports multiple cases for scopes, so this PR adds config to support either camelcase or kebabcase in a commit message's scope:

```
scope(functionName): foo
```
or
```
scope(example-value): foo
```

Closes #472