### PR TITLE
feat: add lengthEq and lengthNotEq

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -834,6 +834,18 @@ declare namespace RamdaAdjunct {
         lengthGte<T>(valueLength: number, list: string | T[]): boolean;
         lengthGte(valueLength: number): <T>(list: string | T[]) => boolean;
 
+         /**
+         * Returns `true` if the supplied list or string has a length equal to `valueLength`.
+         */
+        lengthEq<T>(valueLength: number, list: string | T[]): boolean;
+        lengthEq(valueLength: number): <T>(list: string | T[]) => boolean;
+
+         /**
+         * Returns `true` if the supplied list or string has a length not equal to `valueLength`.
+         */
+        lengthNotEq<T>(valueLength: number, list: string | T[]): boolean;
+        lengthNotEq(valueLength: number): <T>(list: string | T[]) => boolean;
+
         /**
          * Checks if input value is a `thenable`.
          * `thenable` is an object or function that defines a `then` method.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -834,13 +834,13 @@ declare namespace RamdaAdjunct {
         lengthGte<T>(valueLength: number, list: string | T[]): boolean;
         lengthGte(valueLength: number): <T>(list: string | T[]) => boolean;
 
-         /**
+        /**
          * Returns `true` if the supplied list or string has a length equal to `valueLength`.
          */
         lengthEq<T>(valueLength: number, list: string | T[]): boolean;
         lengthEq(valueLength: number): <T>(list: string | T[]) => boolean;
 
-         /**
+        /**
          * Returns `true` if the supplied list or string has a length not equal to `valueLength`.
          */
         lengthNotEq<T>(valueLength: number, list: string | T[]): boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,8 @@ export { default as lengthGt } from './lengthGt';
 export { default as lengthLt } from './lengthLt';
 export { default as lengthGte } from './lengthGte';
 export { default as lengthLte } from './lengthLte';
+export { default as lengthEq } from './lengthEq';
+export { default as lengthNotEq } from './lengthNotEq';
 // Object
 export { default as paths } from './paths';
 export { default as renameKeys } from './renameKeys';

--- a/src/lengthEq.js
+++ b/src/lengthEq.js
@@ -11,10 +11,9 @@ import compareLength from './internal/compareLength';
  * @category List
  * @sig Number -> [*] -> Boolean
  * @param {number} valueLength The length of the list or string
- * @param {number} value The list or string
+ * @param {Array|string} value The list or string
  * @return {boolean}
- * @see {@link http://ramdajs.com/docs/#equals|equals},
- * {@link http://ramdajs.com/docs/#length|length}
+ * @see {@link RA.lengthNotEq|lengthNotEq}, {@link RA.lengthLt|lengthLt}, {@link RA.lengthGt|lengthGt}, {@link RA.lengthLte|lengthLte}, {@link RA.lengthGte|lengthGte},, {@link http://ramdajs.com/docs/#equals|equals}, {@link http://ramdajs.com/docs/#length|length}
  * @example
  *
  * RA.lengthEq(3, [1,2,3]); //=> true

--- a/src/lengthEq.js
+++ b/src/lengthEq.js
@@ -1,0 +1,25 @@
+import { equals } from 'ramda';
+
+import compareLength from './internal/compareLength';
+
+/**
+ * Returns `true` if the supplied list or string has a length equal to `valueLength`.
+ *
+ * @func lengthEq
+ * @memberOf RA
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.8.0|v2.8.0}
+ * @category List
+ * @sig Number -> [*] -> Boolean
+ * @param {number} valueLength The length of the list or string
+ * @param {number} value The list or string
+ * @return {boolean}
+ * @see {@link http://ramdajs.com/docs/#equals|equals},
+ * {@link http://ramdajs.com/docs/#length|length}
+ * @example
+ *
+ * RA.lengthEq(3, [1,2,3]); //=> true
+ * RA.lengthEq(3, [1,2,3,4]); //=> false
+ */
+const lengthEq = compareLength(equals);
+
+export default lengthEq;

--- a/src/lengthGt.js
+++ b/src/lengthGt.js
@@ -1,4 +1,4 @@
-import { gt, flip } from 'ramda';
+import { flip, gt } from 'ramda';
 
 import compareLength from './internal/compareLength';
 
@@ -11,9 +11,9 @@ import compareLength from './internal/compareLength';
  * @category List
  * @sig Number -> [*] -> Boolean
  * @param {number} valueLength The length of the list or string
- * @param {number} value The list or string
+ * @param {Array|string} value The list or string
  * @return {boolean}
- * @see {@link http://ramdajs.com/docs/#gt|gt}, {@link http://ramdajs.com/docs/#length|length}
+ * @see {@link RA.lengthEq|lengthEq}, {@link RA.lengthNotEq|lengthNotEq}, {@link RA.lengthLt|lengthLt}, {@link RA.lengthLte|lengthLte}, {@link RA.lengthGte|lengthGte}, {@link http://ramdajs.com/docs/#gt|gt},  {@link http://ramdajs.com/docs/#length|length}
  * @example
  *
  * RA.lengthGt(3, [1,2,3,4]); //=> true

--- a/src/lengthGte.js
+++ b/src/lengthGte.js
@@ -1,4 +1,4 @@
-import { gte, flip } from 'ramda';
+import { flip, gte } from 'ramda';
 
 import compareLength from './internal/compareLength';
 
@@ -12,9 +12,9 @@ import compareLength from './internal/compareLength';
  * @category List
  * @sig Number -> [*] -> Boolean
  * @param {number} valueLength The length of the list or string
- * @param {number} value The list or string
+ * @param {Array|string} value The list or string
  * @return {boolean}
- * @see {@link http://ramdajs.com/docs/#gte|gte}, {@link http://ramdajs.com/docs/#length|length}
+ * @see {@link RA.lengthEq|lengthEq}, {@link RA.lengthNotEq|lengthNotEq}, {@link RA.lengthLt|lengthLt}, {@link RA.lengthGt|lengthGt}, {@link RA.lengthLte|lengthLte}, {@link http://ramdajs.com/docs/#gte|gte}, {@link http://ramdajs.com/docs/#length|length}
  * @example
  *
  * RA.lengthGte(3, [1,2,3,4]); //=> true

--- a/src/lengthLt.js
+++ b/src/lengthLt.js
@@ -1,4 +1,4 @@
-import { lt, flip } from 'ramda';
+import { flip, lt } from 'ramda';
 
 import compareLength from './internal/compareLength';
 
@@ -11,9 +11,9 @@ import compareLength from './internal/compareLength';
  * @category List
  * @sig Number -> [*] -> Boolean
  * @param {number} valueLength The length of the list or string
- * @param {number} value The list or string
+ * @param {Array|string} value The list or string
  * @return {boolean}
- * @see {@link http://ramdajs.com/docs/#lt|lt}, {@link http://ramdajs.com/docs/#length|length}
+ * @see {@link RA.lengthEq|lengthEq}, {@link RA.lengthNotEq|lengthNotEq}, {@link RA.lengthGt|lengthGt}, {@link RA.lengthLte|lengthLte}, {@link RA.lengthGte|lengthGte}, {@link http://ramdajs.com/docs/#lt|lt}, {@link http://ramdajs.com/docs/#length|length}
  * @example
  *
  * RA.lengthLt(3, [1,2]); //=> true

--- a/src/lengthLte.js
+++ b/src/lengthLte.js
@@ -1,4 +1,4 @@
-import { lte, flip } from 'ramda';
+import { flip, lte } from 'ramda';
 
 import compareLength from './internal/compareLength';
 
@@ -11,9 +11,9 @@ import compareLength from './internal/compareLength';
  * @category List
  * @sig Number -> [*] -> Boolean
  * @param {number} valueLength The length of the list or string
- * @param {number} value The list or string
+ * @param {Array|string} value The list or string
  * @return {boolean}
- * @see {@link http://ramdajs.com/docs/#lte|lte}, {@link http://ramdajs.com/docs/#length|length}
+ * @see {@link RA.lengthEq|lengthEq}, {@link RA.lengthNotEq|lengthNotEq}, {@link RA.lengthLt|lengthLt}, {@link RA.lengthGt|lengthGt}, {@link RA.lengthGte|lengthGte}, {@link http://ramdajs.com/docs/#lte|lte}, {@link http://ramdajs.com/docs/#length|length}
  * @example
  *
  * RA.lengthLte(3, [1,2]); //=> true

--- a/src/lengthNotEq.js
+++ b/src/lengthNotEq.js
@@ -11,10 +11,9 @@ import compareLength from './internal/compareLength';
  * @category List
  * @sig Number -> [*] -> Boolean
  * @param {number} valueLength The length of the list or string
- * @param {number} value The list or string
+ * @param {Array|string} value The list or string
  * @return {boolean}
- * @see {@link http://ramdajs.com/docs/#equals|equals},
- * {@link http://ramdajs.com/docs/#length|length}
+ * @see {@link RA.lengthEq|lengthEq}, {@link RA.lengthLt|lengthLt}, {@link RA.lengthGt|lengthGt}, {@link RA.lengthLte|lengthLte}, {@link RA.lengthGte|lengthGte}, {@link http://ramdajs.com/docs/#equals|equals}, {@link http://ramdajs.com/docs/#length|length}
  * @example
  *
  * RA.lengthNotEq(3, [1,2,3,4]); //=> true

--- a/src/lengthNotEq.js
+++ b/src/lengthNotEq.js
@@ -1,0 +1,25 @@
+import { complement, equals } from 'ramda';
+
+import compareLength from './internal/compareLength';
+
+/**
+ * Returns `true` if the supplied list or string has a length not equal to `valueLength`.
+ *
+ * @func lengthNotEq
+ * @memberOf RA
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.8.0|v2.8.0}
+ * @category List
+ * @sig Number -> [*] -> Boolean
+ * @param {number} valueLength The length of the list or string
+ * @param {number} value The list or string
+ * @return {boolean}
+ * @see {@link http://ramdajs.com/docs/#equals|equals},
+ * {@link http://ramdajs.com/docs/#length|length}
+ * @example
+ *
+ * RA.lengthNotEq(3, [1,2,3,4]); //=> true
+ * RA.lengthNotEq(3, [1,2,3]); //=> false
+ */
+const lengthNotEq = compareLength(complement(equals));
+
+export default lengthNotEq;

--- a/test/lengthEq.js
+++ b/test/lengthEq.js
@@ -1,0 +1,33 @@
+import * as RA from '../src/index';
+import eq from './shared/eq';
+
+describe('lengthEq', function() {
+  it(`should return true if the length of a list is equal to the supplied length`, function() {
+    eq(RA.lengthEq(3, [1, 2, 3]), true);
+    eq(RA.lengthEq(3, [1, 2, 3, 4]), false);
+    eq(RA.lengthEq(3, [1, 2]), false);
+    eq(RA.lengthEq(0, []), true);
+  });
+
+  it(`should return true if the length of a string is equal to the supplied length`, function() {
+    eq(RA.lengthEq(3, 'abc'), true);
+    eq(RA.lengthEq(3, 'abcd'), false);
+    eq(RA.lengthEq(3, 'ab'), false);
+    eq(RA.lengthEq(0, ''), true);
+  });
+
+  it(`should return false for values without a length property`, function() {
+    eq(RA.lengthEq(1, NaN), false);
+    eq(RA.lengthEq(1, undefined), false);
+    eq(RA.lengthEq(1, null), false);
+    eq(RA.lengthEq(1, {}), false);
+    eq(RA.lengthEq(1, true), false);
+    eq(RA.lengthEq(1, false), false);
+    eq(RA.lengthEq(1, 5), false);
+  });
+
+  it(`should be curried`, function() {
+    eq(RA.lengthEq(2, [1, 2]), true);
+    eq(RA.lengthEq(2)([1, 2]), true);
+  });
+});

--- a/test/lengthEq.js
+++ b/test/lengthEq.js
@@ -2,28 +2,40 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 describe('lengthEq', function() {
-  it(`should return true if the length of a list is equal to the supplied length`, function() {
-    eq(RA.lengthEq(3, [1, 2, 3]), true);
-    eq(RA.lengthEq(3, [1, 2, 3, 4]), false);
-    eq(RA.lengthEq(3, [1, 2]), false);
-    eq(RA.lengthEq(0, []), true);
-  });
+  context(
+    `when the length of a list is equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthEq(3, [1, 2, 3]), true);
+        eq(RA.lengthEq(3, [1, 2, 3, 4]), false);
+        eq(RA.lengthEq(3, [1, 2]), false);
+        eq(RA.lengthEq(0, []), true);
+      });
+    }
+  );
 
-  it(`should return true if the length of a string is equal to the supplied length`, function() {
-    eq(RA.lengthEq(3, 'abc'), true);
-    eq(RA.lengthEq(3, 'abcd'), false);
-    eq(RA.lengthEq(3, 'ab'), false);
-    eq(RA.lengthEq(0, ''), true);
-  });
+  context(
+    `when the length of a string is equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthEq(3, 'abc'), true);
+        eq(RA.lengthEq(3, 'abcd'), false);
+        eq(RA.lengthEq(3, 'ab'), false);
+        eq(RA.lengthEq(0, ''), true);
+      });
+    }
+  );
 
-  it(`should return false for values without a length property`, function() {
-    eq(RA.lengthEq(1, NaN), false);
-    eq(RA.lengthEq(1, undefined), false);
-    eq(RA.lengthEq(1, null), false);
-    eq(RA.lengthEq(1, {}), false);
-    eq(RA.lengthEq(1, true), false);
-    eq(RA.lengthEq(1, false), false);
-    eq(RA.lengthEq(1, 5), false);
+  context(`when a value doesn't have a length property`, function() {
+    specify(`should return true`, function() {
+      eq(RA.lengthEq(1, NaN), false);
+      eq(RA.lengthEq(1, undefined), false);
+      eq(RA.lengthEq(1, null), false);
+      eq(RA.lengthEq(1, {}), false);
+      eq(RA.lengthEq(1, true), false);
+      eq(RA.lengthEq(1, false), false);
+      eq(RA.lengthEq(1, 5), false);
+    });
   });
 
   it(`should be curried`, function() {

--- a/test/lengthGt.js
+++ b/test/lengthGt.js
@@ -2,26 +2,38 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 describe('lengthGt', function() {
-  it(`should return true if the length of a list is greater than supplied length`, function() {
-    eq(RA.lengthGt(3, [1, 2, 3, 4]), true);
-    eq(RA.lengthGt(3, [1, 2, 3]), false);
-    eq(RA.lengthGt(0, []), false);
-  });
+  context(
+    `when the length of a list is greater than the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthGt(3, [1, 2, 3, 4]), true);
+        eq(RA.lengthGt(3, [1, 2, 3]), false);
+        eq(RA.lengthGt(0, []), false);
+      });
+    }
+  );
 
-  it(`should return true if the length of a string is greater than supplied length`, function() {
-    eq(RA.lengthGt(3, 'abcd'), true);
-    eq(RA.lengthGt(3, 'abc'), false);
-    eq(RA.lengthGt(0, ''), false);
-  });
+  context(
+    `when the length of a string is greater than the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthGt(3, 'abcd'), true);
+        eq(RA.lengthGt(3, 'abc'), false);
+        eq(RA.lengthGt(0, ''), false);
+      });
+    }
+  );
 
-  it(`should return false for values without a length property`, function() {
-    eq(RA.lengthGt(1, NaN), false);
-    eq(RA.lengthGt(1, undefined), false);
-    eq(RA.lengthGt(1, null), false);
-    eq(RA.lengthGt(1, {}), false);
-    eq(RA.lengthGt(1, true), false);
-    eq(RA.lengthGt(1, false), false);
-    eq(RA.lengthGt(1, 5), false);
+  context(`when a value doesn't have a length property`, function() {
+    specify(`should return false`, function() {
+      eq(RA.lengthGt(1, NaN), false);
+      eq(RA.lengthGt(1, undefined), false);
+      eq(RA.lengthGt(1, null), false);
+      eq(RA.lengthGt(1, {}), false);
+      eq(RA.lengthGt(1, true), false);
+      eq(RA.lengthGt(1, false), false);
+      eq(RA.lengthGt(1, 5), false);
+    });
   });
 
   it(`should be curried`, function() {

--- a/test/lengthGte.js
+++ b/test/lengthGte.js
@@ -2,28 +2,40 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 describe('lengthGte', function() {
-  it(`should return true if the length of a list is greater than or equal to the supplied length`, function() {
-    eq(RA.lengthGte(3, [1, 2, 3, 4]), true);
-    eq(RA.lengthGte(3, [1, 2, 3]), true);
-    eq(RA.lengthGte(3, [1, 2]), false);
-    eq(RA.lengthGte(0, []), true);
-  });
+  context(
+    `when the length of a list is greater than or equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthGte(3, [1, 2, 3, 4]), true);
+        eq(RA.lengthGte(3, [1, 2, 3]), true);
+        eq(RA.lengthGte(3, [1, 2]), false);
+        eq(RA.lengthGte(0, []), true);
+      });
+    }
+  );
 
-  it(`should return true if the length of a string is greater than or equal to the supplied length`, function() {
-    eq(RA.lengthGte(3, 'abcd'), true);
-    eq(RA.lengthGte(3, 'abc'), true);
-    eq(RA.lengthGte(3, 'ab'), false);
-    eq(RA.lengthGte(0, ''), true);
-  });
+  context(
+    `when the length of a string is greater than or equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthGte(3, 'abcd'), true);
+        eq(RA.lengthGte(3, 'abc'), true);
+        eq(RA.lengthGte(3, 'ab'), false);
+        eq(RA.lengthGte(0, ''), true);
+      });
+    }
+  );
 
-  it(`should return false for values without a length property`, function() {
-    eq(RA.lengthGte(1, NaN), false);
-    eq(RA.lengthGte(1, undefined), false);
-    eq(RA.lengthGte(1, null), false);
-    eq(RA.lengthGte(1, {}), false);
-    eq(RA.lengthGte(1, true), false);
-    eq(RA.lengthGte(1, false), false);
-    eq(RA.lengthGte(1, 5), false);
+  context(`when a value doesn't have a length property`, function() {
+    specify(`should return false`, function() {
+      eq(RA.lengthGte(1, NaN), false);
+      eq(RA.lengthGte(1, undefined), false);
+      eq(RA.lengthGte(1, null), false);
+      eq(RA.lengthGte(1, {}), false);
+      eq(RA.lengthGte(1, true), false);
+      eq(RA.lengthGte(1, false), false);
+      eq(RA.lengthGte(1, 5), false);
+    });
   });
 
   it(`should be curried`, function() {

--- a/test/lengthLt.js
+++ b/test/lengthLt.js
@@ -2,26 +2,38 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 describe('lengthLt', function() {
-  it(`should return true if the length of a list is less than supplied length`, function() {
-    eq(RA.lengthLt(3, [1, 2]), true);
-    eq(RA.lengthLt(3, [1, 2, 3]), false);
-    eq(RA.lengthLt(0, []), false);
-  });
+  context(
+    `when the length of a list is less than the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthLt(3, [1, 2]), true);
+        eq(RA.lengthLt(3, [1, 2, 3]), false);
+        eq(RA.lengthLt(0, []), false);
+      });
+    }
+  );
 
-  it(`should return true if the length of a string is less than supplied length`, function() {
-    eq(RA.lengthLt(3, 'ab'), true);
-    eq(RA.lengthLt(3, 'abc'), false);
-    eq(RA.lengthLt(0, ''), false);
-  });
+  context(
+    `when the length of a string is less than the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthLt(3, 'ab'), true);
+        eq(RA.lengthLt(3, 'abc'), false);
+        eq(RA.lengthLt(0, ''), false);
+      });
+    }
+  );
 
-  it(`should return false for values without a length property`, function() {
-    eq(RA.lengthLt(1, NaN), false);
-    eq(RA.lengthLt(1, undefined), false);
-    eq(RA.lengthLt(1, null), false);
-    eq(RA.lengthLt(1, {}), false);
-    eq(RA.lengthLt(1, true), false);
-    eq(RA.lengthLt(1, false), false);
-    eq(RA.lengthLt(1, 5), false);
+  context(`when a value doesn't have a length property`, function() {
+    specify(`should return false`, function() {
+      eq(RA.lengthLt(1, NaN), false);
+      eq(RA.lengthLt(1, undefined), false);
+      eq(RA.lengthLt(1, null), false);
+      eq(RA.lengthLt(1, {}), false);
+      eq(RA.lengthLt(1, true), false);
+      eq(RA.lengthLt(1, false), false);
+      eq(RA.lengthLt(1, 5), false);
+    });
   });
 
   it(`should be curried`, function() {

--- a/test/lengthLte.js
+++ b/test/lengthLte.js
@@ -2,28 +2,40 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 describe('lengthLte', function() {
-  it(`should return true if the length of a list is less than or equal to the supplied length`, function() {
-    eq(RA.lengthLte(3, [1, 2]), true);
-    eq(RA.lengthLte(3, [1, 2, 3]), true);
-    eq(RA.lengthLte(3, [1, 2, 3, 4]), false);
-    eq(RA.lengthLte(0, []), true);
-  });
+  context(
+    `when the length of a list is less than or equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthLte(3, [1, 2]), true);
+        eq(RA.lengthLte(3, [1, 2, 3]), true);
+        eq(RA.lengthLte(3, [1, 2, 3, 4]), false);
+        eq(RA.lengthLte(0, []), true);
+      });
+    }
+  );
 
-  it(`should return true if the length of a string is less than or equal to the supplied length`, function() {
-    eq(RA.lengthLte(3, 'ab'), true);
-    eq(RA.lengthLte(3, 'abc'), true);
-    eq(RA.lengthLte(3, 'abcd'), false);
-    eq(RA.lengthLte(0, ''), true);
-  });
+  context(
+    `when the length of a string is less than or equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthLte(3, 'ab'), true);
+        eq(RA.lengthLte(3, 'abc'), true);
+        eq(RA.lengthLte(3, 'abcd'), false);
+        eq(RA.lengthLte(0, ''), true);
+      });
+    }
+  );
 
-  it(`should return false for values without a length property`, function() {
-    eq(RA.lengthLte(1, NaN), false);
-    eq(RA.lengthLte(1, undefined), false);
-    eq(RA.lengthLte(1, null), false);
-    eq(RA.lengthLte(1, {}), false);
-    eq(RA.lengthLte(1, true), false);
-    eq(RA.lengthLte(1, false), false);
-    eq(RA.lengthLte(1, 5), false);
+  context(`when a value doesn't have a length property`, function() {
+    specify(`should return false`, function() {
+      eq(RA.lengthLte(1, NaN), false);
+      eq(RA.lengthLte(1, undefined), false);
+      eq(RA.lengthLte(1, null), false);
+      eq(RA.lengthLte(1, {}), false);
+      eq(RA.lengthLte(1, true), false);
+      eq(RA.lengthLte(1, false), false);
+      eq(RA.lengthLte(1, 5), false);
+    });
   });
 
   it(`should be curried`, function() {

--- a/test/lengthNotEq.js
+++ b/test/lengthNotEq.js
@@ -1,0 +1,33 @@
+import * as RA from '../src/index';
+import eq from './shared/eq';
+
+describe('lengthNotEq', function() {
+  it(`should return true if the length of a list is not equal to the supplied length`, function() {
+    eq(RA.lengthNotEq(3, [1, 2, 3, 4]), true);
+    eq(RA.lengthNotEq(3, [1, 2]), true);
+    eq(RA.lengthNotEq(3, [1, 2, 3]), false);
+    eq(RA.lengthNotEq(0, []), false);
+  });
+
+  it(`should return true if the length of a string is not equal to the supplied length`, function() {
+    eq(RA.lengthNotEq(3, 'abcd'), true);
+    eq(RA.lengthNotEq(3, 'ab'), true);
+    eq(RA.lengthNotEq(3, 'abc'), false);
+    eq(RA.lengthNotEq(0, ''), false);
+  });
+
+  it(`should return true for values without a length property`, function() {
+    eq(RA.lengthNotEq(1, NaN), true);
+    eq(RA.lengthNotEq(1, undefined), true);
+    eq(RA.lengthNotEq(1, null), true);
+    eq(RA.lengthNotEq(1, {}), true);
+    eq(RA.lengthNotEq(1, true), true);
+    eq(RA.lengthNotEq(1, false), true);
+    eq(RA.lengthNotEq(1, 5), true);
+  });
+
+  it(`should be curried`, function() {
+    eq(RA.lengthNotEq(1, [1, 2]), true);
+    eq(RA.lengthNotEq(1)([1, 2]), true);
+  });
+});

--- a/test/lengthNotEq.js
+++ b/test/lengthNotEq.js
@@ -2,28 +2,40 @@ import * as RA from '../src/index';
 import eq from './shared/eq';
 
 describe('lengthNotEq', function() {
-  it(`should return true if the length of a list is not equal to the supplied length`, function() {
-    eq(RA.lengthNotEq(3, [1, 2, 3, 4]), true);
-    eq(RA.lengthNotEq(3, [1, 2]), true);
-    eq(RA.lengthNotEq(3, [1, 2, 3]), false);
-    eq(RA.lengthNotEq(0, []), false);
-  });
+  context(
+    `when the length of a list is not equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthNotEq(3, [1, 2, 3, 4]), true);
+        eq(RA.lengthNotEq(3, [1, 2]), true);
+        eq(RA.lengthNotEq(3, [1, 2, 3]), false);
+        eq(RA.lengthNotEq(0, []), false);
+      });
+    }
+  );
 
-  it(`should return true if the length of a string is not equal to the supplied length`, function() {
-    eq(RA.lengthNotEq(3, 'abcd'), true);
-    eq(RA.lengthNotEq(3, 'ab'), true);
-    eq(RA.lengthNotEq(3, 'abc'), false);
-    eq(RA.lengthNotEq(0, ''), false);
-  });
+  context(
+    `when the length of a string is not equal to the supplied length`,
+    function() {
+      specify(`should return true`, function() {
+        eq(RA.lengthNotEq(3, 'abcd'), true);
+        eq(RA.lengthNotEq(3, 'ab'), true);
+        eq(RA.lengthNotEq(3, 'abc'), false);
+        eq(RA.lengthNotEq(0, ''), false);
+      });
+    }
+  );
 
-  it(`should return true for values without a length property`, function() {
-    eq(RA.lengthNotEq(1, NaN), true);
-    eq(RA.lengthNotEq(1, undefined), true);
-    eq(RA.lengthNotEq(1, null), true);
-    eq(RA.lengthNotEq(1, {}), true);
-    eq(RA.lengthNotEq(1, true), true);
-    eq(RA.lengthNotEq(1, false), true);
-    eq(RA.lengthNotEq(1, 5), true);
+  context(`when a value doesn't have a length property`, function() {
+    specify(`should return true`, function() {
+      eq(RA.lengthNotEq(1, NaN), true);
+      eq(RA.lengthNotEq(1, undefined), true);
+      eq(RA.lengthNotEq(1, null), true);
+      eq(RA.lengthNotEq(1, {}), true);
+      eq(RA.lengthNotEq(1, true), true);
+      eq(RA.lengthNotEq(1, false), true);
+      eq(RA.lengthNotEq(1, 5), true);
+    });
   });
 
   it(`should be curried`, function() {


### PR DESCRIPTION
Adds remaining functions to test of list or string length is equal or notEqual to the supplied length.

Note: I'm unsure of the correct behaviour for `lengthNotEq` when the value supplied does not have a length property. I am returning false, but should we do something else?

Closes #444