### PR TITLE
chore(package): update eslint-config-airbnb-base to v13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
   },
   "devDependencies": {
     "@commitlint/cli": "7.1.0",
-    "@commitlint/config-conventional": "7.1.0",
     "@commitlint/config-conventional": "7.1.2",
     "babel-cli": "=6.26.0",
     "babel-core": "=6.26.0",
@@ -128,7 +127,7 @@
     "cross-env": "5.2.0",
     "conventional-changelog-cli": "2.0.1",
     "docdash": "git+https://github.com/char0n/docdash.git#bf4b4eebfdaf042c0ea9038419bc26813f243c94",
-    "eslint-config-airbnb-base": "13.0.0",
+    "eslint-config-airbnb-base": "13.1.0",
     "eslint": "5.0.1",
     "eslint-config-prettier": "2.10.0",
     "eslint-plugin-import": "2.13.0",


### PR DESCRIPTION
This suppress deprecation warnings that were present before this update

