### PR TITLE
feat: add repeatStr

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -861,6 +861,13 @@ declare namespace RamdaAdjunct {
         allEqual<T>(list: T[]): boolean;
 
         /**
+         * Constructs and returns a new string which contains the specified
+         * number of copies of the string on which it was called, concatenated together.
+         */
+        repeatStr(value: string, count: number): string;
+        repeatStr(value: string): (count: number) => string;
+
+        /**
          * Checks if input value is a `thenable`.
          * `thenable` is an object or function that defines a `then` method.
          */

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ export { default as lengthLte } from './lengthLte';
 export { default as lengthEq } from './lengthEq';
 export { default as lengthNotEq } from './lengthNotEq';
 export { default as allEqual } from './allEqual';
+export { default as repeatStr } from './repeatStr';
 // Object
 export { default as paths } from './paths';
 export { default as renameKeys } from './renameKeys';

--- a/src/internal/polyfills/String.repeat.js
+++ b/src/internal/polyfills/String.repeat.js
@@ -1,0 +1,49 @@
+import isNotFinite from '../../isNotFinite';
+import isNegative from '../../isNegative';
+
+const repeat = (value, count) => {
+  let validCount = Number(count);
+
+  if (validCount !== count) {
+    validCount = 0;
+  }
+
+  if (isNegative(validCount)) {
+    throw new RangeError('repeat count must be non-negative');
+  }
+
+  if (isNotFinite(validCount)) {
+    throw new RangeError('repeat count must be less than infinity');
+  }
+
+  validCount = Math.floor(validCount);
+
+  if (value.length === 0 || validCount === 0) {
+    return '';
+  }
+
+  // Ensuring validCount is a 31-bit integer allows us to heavily optimize the
+  // main part. But anyway, most current (August 2014) browsers can't handle
+  // strings 1 << 28 chars or longer, so:
+  // eslint-disable-next-line no-bitwise
+  if (value.length * validCount >= 1 << 28) {
+    throw new RangeError('repeat count must not overflow maximum string size');
+  }
+
+  const maxCount = value.length * validCount;
+
+  validCount = Math.floor(Math.log(validCount) / Math.log(2));
+
+  let result = value;
+
+  while (validCount) {
+    result += value;
+    validCount -= 1;
+  }
+
+  result += result.substring(0, maxCount - result.length);
+
+  return result;
+};
+
+export default repeat;

--- a/src/repeatStr.js
+++ b/src/repeatStr.js
@@ -1,0 +1,30 @@
+import { curry, invoker, flip } from 'ramda';
+
+import polyfill from './internal/polyfills/String.repeat';
+import isFunction from './isFunction';
+
+export const repeatStrPolyfill = curry(polyfill);
+
+export const repeatStrInvoker = flip(invoker(1, 'repeat'));
+
+/**
+ * Constructs and returns a new string which contains the specified
+ * number of copies of the string on which it was called, concatenated together.
+ *
+ * @func repeatStr
+ * @memberOf RA
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.11.0|v2.11.0}
+ * @category List
+ * @sig String -> Number -> String
+ * @param {string} value String value to be repeated
+ * @param {number} count An integer between 0 and +∞: [0, +∞), indicating the number of times to repeat the string in the newly-created string that is to be returned
+ * @return {string} A new string containing the specified number of copies of the given string
+ * @example
+ *
+ * RA.repeatStr('a', 3); //=> 'aaa'
+ */
+const repeatStr = isFunction(String.prototype.repeat)
+  ? repeatStrInvoker
+  : repeatStrPolyfill;
+
+export default repeatStr;

--- a/test/repeatStr.js
+++ b/test/repeatStr.js
@@ -1,0 +1,161 @@
+import { assert } from 'chai';
+
+import * as RA from '../src';
+import { repeatStrInvoker, repeatStrPolyfill } from '../src/repeatStr';
+import eq from './shared/eq';
+
+describe('repeatStr', function() {
+  specify('should repeat string n times', function() {
+    eq(RA.repeatStr('abc', 3), 'abcabcabc');
+  });
+
+  context('given count 0', function() {
+    specify('should return empty string', function() {
+      eq(RA.repeatStr('abc', 0), '');
+    });
+  });
+
+  context('given count 1', function() {
+    specify('should return original string', function() {
+      eq(RA.repeatStr('abc', 1), 'abc');
+    });
+  });
+
+  context('given count supplied as float', function() {
+    specify('should convert count to integer', function() {
+      eq(RA.repeatStr('abc', 3.5), 'abcabcabc');
+    });
+  });
+
+  context('given count is negative number', function() {
+    specify('should throw RangeError', function() {
+      assert.throws(() => RA.repeatStr('abc', -1), RangeError);
+    });
+  });
+
+  context('given count is Infinity', function() {
+    specify('should throw RangeError', function() {
+      assert.throws(() => RA.repeatStr('abc', 1 / 0), RangeError);
+    });
+  });
+
+  context('given count is not a number', function() {
+    specify('should return empty string', function() {
+      eq(RA.repeatStr('abc', 'a'), '');
+      eq(RA.repeatStr('abc', null), '');
+      eq(RA.repeatStr('abc', undefined), '');
+      eq(RA.repeatStr('abc', NaN), '');
+    });
+  });
+
+  specify('should be curried', function() {
+    eq(RA.repeatStr('abc', 3.5), 'abcabcabc');
+    eq(RA.repeatStr('abc')(3.5), 'abcabcabc');
+  });
+
+  context('repeatStrInvoker', function() {
+    beforeEach(function() {
+      if (RA.isNotFunction(String.prototype.repeat)) {
+        this.skip();
+      }
+    });
+
+    specify('should repeat string n times', function() {
+      eq(repeatStrInvoker('abc', 3), 'abcabcabc');
+    });
+
+    context('given count 0', function() {
+      specify('should return empty string', function() {
+        eq(repeatStrInvoker('abc', 0), '');
+      });
+    });
+
+    context('given count 1', function() {
+      specify('should return original string', function() {
+        eq(repeatStrInvoker('abc', 1), 'abc');
+      });
+    });
+
+    context('given count supplied as float', function() {
+      specify('should convert count to integer', function() {
+        eq(repeatStrInvoker('abc', 3.5), 'abcabcabc');
+      });
+    });
+
+    context('given count is negative number', function() {
+      specify('should throw RangeError', function() {
+        assert.throws(() => repeatStrInvoker('abc', -1), RangeError);
+      });
+    });
+
+    context('given count is Infinity', function() {
+      specify('should throw RangeError', function() {
+        assert.throws(() => repeatStrInvoker('abc', 1 / 0), RangeError);
+      });
+    });
+
+    context('given count is not a number', function() {
+      specify('should return empty string', function() {
+        eq(repeatStrInvoker('abc', 'a'), '');
+        eq(repeatStrInvoker('abc', null), '');
+        eq(repeatStrInvoker('abc', undefined), '');
+        eq(repeatStrInvoker('abc', NaN), '');
+      });
+    });
+
+    specify('should be curried', function() {
+      eq(repeatStrInvoker('abc', 3.5), 'abcabcabc');
+      eq(repeatStrInvoker('abc')(3.5), 'abcabcabc');
+    });
+  });
+
+  context('repeatStrPolyfill', function() {
+    specify('should repeat string n times', function() {
+      eq(repeatStrPolyfill('abc', 3), 'abcabcabc');
+    });
+
+    context('given count 0', function() {
+      specify('should return empty string', function() {
+        eq(repeatStrPolyfill('abc', 0), '');
+      });
+    });
+
+    context('given count 1', function() {
+      specify('should return original string', function() {
+        eq(repeatStrPolyfill('abc', 1), 'abc');
+      });
+    });
+
+    context('given count supplied as float', function() {
+      specify('should convert count to integer', function() {
+        eq(repeatStrPolyfill('abc', 3.5), 'abcabcabc');
+      });
+    });
+
+    context('given count is negative number', function() {
+      specify('should throw RangeError', function() {
+        assert.throws(() => repeatStrPolyfill('abc', -1), RangeError);
+      });
+    });
+
+    context('given count is Infinity', function() {
+      specify('should throw RangeError', function() {
+        assert.throws(() => repeatStrPolyfill('abc', 1 / 0), RangeError);
+      });
+    });
+
+    context('given count is not a number', function() {
+      specify('should return empty string', function() {
+        eq(repeatStrPolyfill('abc', 'a'), '');
+        eq(repeatStrPolyfill('abc', null), '');
+        eq(repeatStrPolyfill('abc', undefined), '');
+        eq(repeatStrPolyfill('abc', NaN), '');
+      });
+    });
+
+    specify('should be curried', function() {
+      eq(repeatStrPolyfill('abc', 3.5), 'abcabcabc');
+      eq(repeatStrPolyfill('abc')(3.5), 'abcabcabc');
+    });
+  });
+});


### PR DESCRIPTION
Ref #667

I made this consistent with https://ramdajs.com/docs/#repeat. The data seems to be the first argument and I suppose there is a reason for this. To make it truly functional without consulting ramda, I'd switch the order of the arguments. In FP the data should be always last. 