### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#1

### DIFF
--- a/test/async.js
+++ b/test/async.js
@@ -1,7 +1,6 @@
 import * as R from 'ramda';
 import { assert } from 'chai';
 
-import eq from './shared/eq';
 import * as RA from '../src';
 
 describe('async', function() {
@@ -15,7 +14,7 @@ describe('async', function() {
       });
       const expected = await asyncFn(1, 2);
 
-      eq(expected, 3);
+      assert.strictEqual(expected, 3);
     });
 
     context('and the generator throw Error as the last statement', function() {
@@ -32,7 +31,7 @@ describe('async', function() {
           throw new Error('fulfilling should fail');
         } catch (error) {
           assert.instanceOf(error, Error);
-          eq(error.message, 'generator error');
+          assert.strictEqual(error.message, 'generator error');
         }
       });
     });
@@ -49,7 +48,7 @@ describe('async', function() {
           throw new Error('fulfilling should fail');
         } catch (error) {
           assert.instanceOf(error, Error);
-          eq(error.message, 'generator error');
+          assert.strictEqual(error.message, 'generator error');
         }
       });
     });
@@ -66,7 +65,7 @@ describe('async', function() {
           throw new Error('fulfilling should fail');
         } catch (error) {
           assert.instanceOf(error, Error);
-          eq(error.message, 'generator error');
+          assert.strictEqual(error.message, 'generator error');
         }
       });
     });
@@ -92,7 +91,7 @@ describe('async', function() {
             return c + 3;
           });
 
-          eq(await bar(1, 2), 9);
+          assert.strictEqual(await bar(1, 2), 9);
         });
       }
     );
@@ -116,7 +115,7 @@ describe('async', function() {
           return c + 3;
         });
 
-        eq(await bar(1, 2), 9);
+        assert.strictEqual(await bar(1, 2), 9);
       });
     });
   });
@@ -136,7 +135,7 @@ describe('async', function() {
       return c + 3;
     });
 
-    eq(await bar(1, 2), 6);
+    assert.strictEqual(await bar(1, 2), 6);
   });
 
   it('should support async delegation', async function() {
@@ -154,7 +153,7 @@ describe('async', function() {
       return c + 3;
     });
 
-    eq(await bar(1, 2), 6);
+    assert.strictEqual(await bar(1, 2), 6);
   });
 
   it('should support recursion delegation', async function() {
@@ -168,7 +167,7 @@ describe('async', function() {
       return yield newVal;
     });
 
-    eq(await async(10), 1);
+    assert.strictEqual(await async(10), 1);
   });
 
   it('should curry', async function() {
@@ -179,7 +178,7 @@ describe('async', function() {
     });
     const expected = await asyncFn();
 
-    eq(expected, 2);
+    assert.strictEqual(expected, 2);
   });
 
   context('given wrapping of generator with arity of 2', function() {
@@ -193,12 +192,12 @@ describe('async', function() {
     });
 
     specify('should translate generator arity to wrapper', function() {
-      eq(asyncFn.length, 2);
+      assert.strictEqual(asyncFn.length, 2);
     });
 
     specify('should curry wrapper to appropriate arity', async function() {
-      eq(await asyncFn(1, 2), 3);
-      eq(await asyncFn(1)(2), 3);
+      assert.strictEqual(await asyncFn(1, 2), 3);
+      assert.strictEqual(await asyncFn(1)(2), 3);
     });
   });
 
@@ -216,13 +215,13 @@ describe('async', function() {
       specify('should not support placeholder', async function() {
         const expected = await asyncFn(R.__);
 
-        eq(expected, 1);
+        assert.strictEqual(expected, 1);
       });
 
       specify('should support call without arguments', async function() {
         const expected = await asyncFn();
 
-        eq(expected, 1);
+        assert.strictEqual(expected, 1);
       });
     });
   });

--- a/test/ceil.js
+++ b/test/ceil.js
@@ -2,42 +2,41 @@ import * as R from 'ramda';
 import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 
 describe('ceil', function() {
   it('should ceil float to nearest integer', function() {
-    eq(RA.ceil(0.9), 1);
-    eq(RA.ceil(5.95), 6);
-    eq(RA.ceil(5.5), 6);
-    eq(RA.ceil(5.05), 6);
-    eq(RA.ceil(-5.05), -5);
-    eq(RA.ceil(-5.5), -5);
-    eq(RA.ceil(-5.95), -5);
+    assert.strictEqual(RA.ceil(0.9), 1);
+    assert.strictEqual(RA.ceil(5.95), 6);
+    assert.strictEqual(RA.ceil(5.5), 6);
+    assert.strictEqual(RA.ceil(5.05), 6);
+    assert.strictEqual(RA.ceil(-5.05), -5);
+    assert.strictEqual(RA.ceil(-5.5), -5);
+    assert.strictEqual(RA.ceil(-5.95), -5);
   });
 
   context('given integer number', function() {
     specify('should return original integer number', function() {
-      eq(RA.ceil(0), 0);
-      eq(RA.ceil(1), 1);
-      eq(RA.ceil(-1), -1);
+      assert.strictEqual(RA.ceil(0), 0);
+      assert.strictEqual(RA.ceil(1), 1);
+      assert.strictEqual(RA.ceil(-1), -1);
     });
   });
 
   context('given value that is not a number', function() {
     specify('should return NaN', function() {
-      eq(RA.ceil(undefined), NaN);
-      eq(RA.ceil(NaN), NaN);
-      eq(RA.ceil({}), NaN);
-      eq(RA.ceil(/a/), NaN);
-      eq(RA.ceil('test'), NaN);
-      eq(RA.ceil(new Error()), NaN);
+      assert.isNaN(RA.ceil(undefined));
+      assert.isNaN(RA.ceil(NaN));
+      assert.isNaN(RA.ceil({}));
+      assert.isNaN(RA.ceil(/a/));
+      assert.isNaN(RA.ceil('test'));
+      assert.isNaN(RA.ceil(new Error()));
     });
   });
 
   context('given null', function() {
     specify('should return 0', function() {
-      eq(RA.ceil(null), 0);
+      assert.strictEqual(RA.ceil(null), 0);
     });
   });
 
@@ -61,21 +60,21 @@ describe('ceil', function() {
     specify(
       'should return the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC',
       function() {
-        eq(RA.ceil(new Date(2)), 2);
+        assert.strictEqual(RA.ceil(new Date(2)), 2);
       }
     );
   });
 
   context('given Infinity value', function() {
     specify('should return untouched Infinity value', function() {
-      eq(RA.ceil(Infinity), Infinity);
-      eq(RA.ceil(-Infinity), -Infinity);
+      assert.strictEqual(RA.ceil(Infinity), Infinity);
+      assert.strictEqual(RA.ceil(-Infinity), -Infinity);
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const ceil = RA.ceil(R.__);
 
-    eq(ceil(0.9), 1);
+    assert.strictEqual(ceil(0.9), 1);
   });
 });

--- a/test/compact.js
+++ b/test/compact.js
@@ -2,18 +2,20 @@ import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('compact', function() {
   context('given list contains falsy values', function() {
     specify('should filter them', function() {
-      eq(RA.compact([0, 1, false, 2, '', 3, null, undefined, NaN]), [1, 2, 3]);
+      assert.sameOrderedMembers(
+        RA.compact([0, 1, false, 2, '', 3, null, undefined, NaN]),
+        [1, 2, 3]
+      );
     });
   });
 
   context('given list contains truthy values only', function() {
     specify('should not filter anything', function() {
-      eq(RA.compact([1, 2, 3]), [1, 2, 3]);
+      assert.sameOrderedMembers(RA.compact([1, 2, 3]), [1, 2, 3]);
     });
 
     specify('should return new list with exactly same items', function() {
@@ -34,6 +36,6 @@ describe('compact', function() {
   it('should support placeholder to specify "gaps"', function() {
     const compact = RA.compact(R.__);
 
-    eq(compact([]), []);
+    assert.sameOrderedMembers(compact([]), []);
   });
 });

--- a/test/concatAll.js
+++ b/test/concatAll.js
@@ -3,24 +3,23 @@ import { NEL, Nil } from 'monet';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('concatAll', function() {
   it('should concatenate arrays', function() {
-    eq(RA.concatAll([[1], [2], [3]]), [1, 2, 3]);
+    assert.sameOrderedMembers(RA.concatAll([[1], [2], [3]]), [1, 2, 3]);
   });
 
   it('should concatenate strings', function() {
-    eq(RA.concatAll(['1', '2', '3']), '123');
+    assert.strictEqual(RA.concatAll(['1', '2', '3']), '123');
   });
 
   it('should concatenate semigroups', function() {
-    eq(RA.concatAll([NEL(1), NEL(2)]), NEL(1, NEL(2, Nil)));
+    assert.deepEqual(RA.concatAll([NEL(1), NEL(2)]), NEL(1, NEL(2, Nil)));
   });
 
   context('given foldable is empty', function() {
     specify('should returns undefined', function() {
-      eq(RA.concatAll([]), undefined);
+      assert.isUndefined(RA.concatAll([]));
     });
   });
 
@@ -48,6 +47,6 @@ describe('concatAll', function() {
   it('should support placeholder to specify "gaps"', function() {
     const concatAll = RA.concatAll(R.__);
 
-    eq(concatAll(['1', '2', '3']), '123');
+    assert.strictEqual(concatAll(['1', '2', '3']), '123');
   });
 });

--- a/test/concatRight.js
+++ b/test/concatRight.js
@@ -1,7 +1,6 @@
 import * as R from 'ramda';
 import { assert } from 'chai';
 
-import eq from './shared/eq';
 import * as RA from '../src';
 
 describe('concatRight', function() {
@@ -14,31 +13,43 @@ describe('concatRight', function() {
   const z2 = { x: 'z2' };
 
   it('should add combines the elements of the two lists', function() {
-    eq(RA.concatRight(['a', 'b'], ['c', 'd']), ['c', 'd', 'a', 'b']);
-    eq(RA.concatRight([], ['c', 'd']), ['c', 'd']);
+    assert.sameOrderedMembers(RA.concatRight(['a', 'b'], ['c', 'd']), [
+      'c',
+      'd',
+      'a',
+      'b',
+    ]);
+    assert.sameOrderedMembers(RA.concatRight([], ['c', 'd']), ['c', 'd']);
   });
 
   it('should work on strings', function() {
-    eq(RA.concatRight('foo', 'bar'), 'barfoo');
-    eq(RA.concatRight('x', ''), 'x');
-    eq(RA.concatRight('', 'x'), 'x');
-    eq(RA.concatRight('', ''), '');
+    assert.strictEqual(RA.concatRight('foo', 'bar'), 'barfoo');
+    assert.strictEqual(RA.concatRight('x', ''), 'x');
+    assert.strictEqual(RA.concatRight('', 'x'), 'x');
+    assert.strictEqual(RA.concatRight('', ''), '');
   });
 
   it('should delegate to non-String object with a concat method, as first param', function() {
-    eq(RA.concatRight(z2, z1), 'z1 z2');
+    assert.strictEqual(RA.concatRight(z2, z1), 'z1 z2');
   });
 
   it('should be curried', function() {
     const conc123 = RA.concatRight([1, 2, 3]);
-    eq(conc123([4, 5, 6]), [4, 5, 6, 1, 2, 3]);
-    eq(conc123(['a', 'b', 'c']), ['a', 'b', 'c', 1, 2, 3]);
+    assert.sameOrderedMembers(conc123([4, 5, 6]), [4, 5, 6, 1, 2, 3]);
+    assert.sameOrderedMembers(conc123(['a', 'b', 'c']), [
+      'a',
+      'b',
+      'c',
+      1,
+      2,
+      3,
+    ]);
   });
 
   it('should be curried like a binary operator, that accepts an initial placeholder', function() {
     const appendBar = RA.concatRight(R.__, 'bar');
-    eq(typeof appendBar, 'function');
-    eq(appendBar('foo'), 'barfoo');
+    assert.strictEqual(typeof appendBar, 'function');
+    assert.strictEqual(appendBar('foo'), 'barfoo');
   });
 
   context('given attempting to combine an array with a non-array', function() {
@@ -57,7 +68,17 @@ describe('concatRight', function() {
   );
 
   it('should curry', function() {
-    eq(RA.concatRight(['a', 'b'], ['c', 'd']), ['c', 'd', 'a', 'b']);
-    eq(RA.concatRight(['a', 'b'])(['c', 'd']), ['c', 'd', 'a', 'b']);
+    assert.sameOrderedMembers(RA.concatRight(['a', 'b'], ['c', 'd']), [
+      'c',
+      'd',
+      'a',
+      'b',
+    ]);
+    assert.sameOrderedMembers(RA.concatRight(['a', 'b'])(['c', 'd']), [
+      'c',
+      'd',
+      'a',
+      'b',
+    ]);
   });
 });


### PR DESCRIPTION
Batch 1

test/
- async.js
-   ceil.js
-   compact.js
-   concatAll.js
-   concatRight.js
