### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#2

### DIFF
--- a/test/contained.js
+++ b/test/contained.js
@@ -1,24 +1,24 @@
 import * as R from 'ramda';
+import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('contained', function() {
   context('given element is in the list', function() {
     specify('should return true', function() {
-      eq(RA.contained([1, 2, 3, 9, 8, 7, 100, 200, 300], 7), true);
+      assert.isTrue(RA.contained([1, 2, 3, 9, 8, 7, 100, 200, 300], 7));
     });
   });
 
   context('given element is not in the list', function() {
     specify('should return false', function() {
-      eq(RA.contained([1, 2, 3, 9, 8, 7, 100, 200, 300], 99), false);
+      assert.isFalse(RA.contained([1, 2, 3, 9, 8, 7, 100, 200, 300], 99));
     });
   });
 
   context('given empty list', function() {
     specify('should return false', function() {
-      eq(RA.contained([], 1), false);
+      assert.isFalse(RA.contained([], 1));
     });
   });
 
@@ -30,20 +30,20 @@ describe('contained', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    eq(RA.contained([-0], 0), false);
-    eq(RA.contained([0], -0), false);
-    eq(RA.contained([NaN], NaN), true);
-    eq(RA.contained([new Just([42])], new Just([42])), true);
+    assert.isFalse(RA.contained([-0], 0));
+    assert.isFalse(RA.contained([0], -0));
+    assert.isTrue(RA.contained([NaN], NaN));
+    assert.isTrue(RA.contained([new Just([42])], new Just([42])));
   });
 
   context('given substring is part of string', function() {
     it('should return true', function() {
-      eq(RA.contained('banana', 'ba'), true);
+      assert.isTrue(RA.contained('banana', 'ba'));
     });
   });
 
   it('should be curried', function() {
-    eq(RA.contained('abcd', 'b'), true);
-    eq(RA.contained('abcd')('b'), true);
+    assert.isTrue(RA.contained('abcd', 'b'));
+    assert.isTrue(RA.contained('abcd')('b'));
   });
 });

--- a/test/curryRight.js
+++ b/test/curryRight.js
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import jsv from 'jsverify';
+import { assert } from 'chai';
 
-import eq from './shared/eq';
 import * as RA from '../src';
 
 describe('curryRight', function() {
@@ -10,7 +10,7 @@ describe('curryRight', function() {
       return (a + b * c) / d;
     }); // f(2, 6, 3, 10) == 2
     const g = f(10);
-    eq(g(3, 6, 2), 2);
+    assert.strictEqual(g(3, 6, 2), 2);
   });
 
   it('should curry multiple values', function() {
@@ -19,9 +19,9 @@ describe('curryRight', function() {
       return (a + b * c) / d;
     });
     const g = f(10, 3);
-    eq(g(6, 2), 2);
+    assert.strictEqual(g(6, 2), 2);
     const h = f(10, 3, 6);
-    eq(h(2), 2);
+    assert.strictEqual(h(2), 2);
   });
 
   it('should allow further currying of a curried function', function() {
@@ -30,22 +30,22 @@ describe('curryRight', function() {
       return (a + b * c) / d;
     });
     const g = f(10);
-    eq(g(3, 6, 2), 2);
+    assert.strictEqual(g(3, 6, 2), 2);
     const h = g(3);
-    eq(h(6, 2), 2);
-    eq(g(3, 6)(2), 2);
+    assert.strictEqual(h(6, 2), 2);
+    assert.strictEqual(g(3, 6)(2), 2);
   });
 
   it('should properly report the length of the curried function', function() {
     const f = RA.curryRight(function(a, b, c, d) {
       return (a + b * c) / d;
     });
-    eq(f.length, 4);
+    assert.strictEqual(f.length, 4);
     const g = f(10);
-    eq(g.length, 3);
+    assert.strictEqual(g.length, 3);
     const h = g(3);
-    eq(h.length, 2);
-    eq(g(3, 6).length, 1);
+    assert.strictEqual(h.length, 2);
+    assert.strictEqual(g(3, 6).length, 1);
   });
 
   it('should preserve context', function() {
@@ -55,8 +55,8 @@ describe('curryRight', function() {
     };
     const g = RA.curryRight(f);
 
-    eq(g.call(ctx, 2, 4), 24);
-    eq(g.call(ctx, 2).call(ctx, 4), 24);
+    assert.strictEqual(g.call(ctx, 2, 4), 24);
+    assert.strictEqual(g.call(ctx, 2).call(ctx, 4), 24);
   });
 
   it('should support R.__ placeholder', function() {
@@ -66,29 +66,29 @@ describe('curryRight', function() {
     const g = RA.curryRight(f);
     const _ = R.__;
 
-    eq(g(1)(2)(3), [3, 2, 1]);
-    eq(g(1)(2, 3), [3, 2, 1]);
-    eq(g(1, 2)(3), [3, 2, 1]);
-    eq(g(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3), [3, 2, 1]);
 
-    eq(g(_, 2, 3)(1), [3, 2, 1]);
-    eq(g(1, _, 3)(2), [3, 2, 1]);
-    eq(g(1, 2, _)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, _)(3), [3, 2, 1]);
 
-    eq(g(1, _, _)(2)(3), [3, 2, 1]);
-    eq(g(_, 2, _)(1)(3), [3, 2, 1]);
-    eq(g(_, _, 3)(1)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1)(2), [3, 2, 1]);
 
-    eq(g(1, _, _)(2, 3), [3, 2, 1]);
-    eq(g(_, 2, _)(1, 3), [3, 2, 1]);
-    eq(g(_, _, 3)(1, 2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1, 2), [3, 2, 1]);
 
-    eq(g(1, _, _)(_, 3)(2), [3, 2, 1]);
-    eq(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
-    eq(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(_, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
 
-    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
-    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
   });
 
   it('should support @@functional/placeholder', function() {
@@ -98,29 +98,29 @@ describe('curryRight', function() {
     const g = RA.curryRight(f);
     const _ = { '@@functional/placeholder': true, x: Math.random() };
 
-    eq(g(1)(2)(3), [3, 2, 1]);
-    eq(g(1)(2, 3), [3, 2, 1]);
-    eq(g(1, 2)(3), [3, 2, 1]);
-    eq(g(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3), [3, 2, 1]);
 
-    eq(g(_, 2, 3)(1), [3, 2, 1]);
-    eq(g(1, _, 3)(2), [3, 2, 1]);
-    eq(g(1, 2, _)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, _)(3), [3, 2, 1]);
 
-    eq(g(1, _, _)(2)(3), [3, 2, 1]);
-    eq(g(_, 2, _)(1)(3), [3, 2, 1]);
-    eq(g(_, _, 3)(1)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1)(2), [3, 2, 1]);
 
-    eq(g(1, _, _)(2, 3), [3, 2, 1]);
-    eq(g(_, 2, _)(1, 3), [3, 2, 1]);
-    eq(g(_, _, 3)(1, 2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1, 2), [3, 2, 1]);
 
-    eq(g(1, _, _)(_, 3)(2), [3, 2, 1]);
-    eq(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
-    eq(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(_, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
 
-    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
-    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
   });
 
   it('should forward extra arguments', function() {
@@ -130,11 +130,11 @@ describe('curryRight', function() {
     };
     const g = RA.curryRight(f);
 
-    eq(g(1, 2, 3), [3, 2, 1]);
-    eq(g(1, 2, 3, 4), [4, 3, 2, 1]);
-    eq(g(1, 2)(3, 4), [4, 3, 2, 1]);
-    eq(g(1)(2, 3, 4), [4, 3, 2, 1]);
-    eq(g(1)(2)(3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2)(3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2, 3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2)(3, 4), [4, 3, 2, 1]);
   });
 });
 

--- a/test/curryRightN.js
+++ b/test/curryRightN.js
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
+import { assert } from 'chai';
 
-import eq from './shared/eq';
 import * as RA from '../src';
 
 describe('curryRightN', function() {
@@ -11,20 +11,20 @@ describe('curryRightN', function() {
 
   it('should accept an arity', function() {
     const curried = RA.curryRightN(3, source);
-    eq(curried(1)(2)(3), 6);
-    eq(curried(1, 2)(3), 6);
-    eq(curried(1)(2, 3), 6);
-    eq(curried(1, 2, 3), 6);
+    assert.strictEqual(curried(1)(2)(3), 6);
+    assert.strictEqual(curried(1, 2)(3), 6);
+    assert.strictEqual(curried(1)(2, 3), 6);
+    assert.strictEqual(curried(1, 2, 3), 6);
   });
 
   it('should support partial application/currying', function() {
     const curryRight3 = RA.curryRightN(3);
     const curried = curryRight3(source);
-    eq(curried.length, 3);
-    eq(curried(1)(2)(3), 6);
-    eq(curried(1, 2)(3), 6);
-    eq(curried(1)(2, 3), 6);
-    eq(curried(1, 2, 3), 6);
+    assert.strictEqual(curried.length, 3);
+    assert.strictEqual(curried(1)(2)(3), 6);
+    assert.strictEqual(curried(1, 2)(3), 6);
+    assert.strictEqual(curried(1)(2, 3), 6);
+    assert.strictEqual(curried(1, 2, 3), 6);
   });
 
   it('should preserve context', function() {
@@ -34,8 +34,8 @@ describe('curryRightN', function() {
     };
     const g = RA.curryRightN(2, f);
 
-    eq(g.call(ctx, 2, 4), 24);
-    eq(g.call(ctx, 2).call(ctx, 4), 24);
+    assert.strictEqual(g.call(ctx, 2, 4), 24);
+    assert.strictEqual(g.call(ctx, 2).call(ctx, 4), 24);
   });
 
   it('should support R.__ placeholder', function() {
@@ -45,29 +45,29 @@ describe('curryRightN', function() {
     const g = RA.curryRightN(3, f);
     const _ = R.__;
 
-    eq(g(1)(2)(3), [3, 2, 1]);
-    eq(g(1)(2, 3), [3, 2, 1]);
-    eq(g(1, 2)(3), [3, 2, 1]);
-    eq(g(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3), [3, 2, 1]);
 
-    eq(g(_, 2, 3)(1), [3, 2, 1]);
-    eq(g(1, _, 3)(2), [3, 2, 1]);
-    eq(g(1, 2, _)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, _)(3), [3, 2, 1]);
 
-    eq(g(1, _, _)(2)(3), [3, 2, 1]);
-    eq(g(_, 2, _)(1)(3), [3, 2, 1]);
-    eq(g(_, _, 3)(1)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1)(2), [3, 2, 1]);
 
-    eq(g(1, _, _)(2, 3), [3, 2, 1]);
-    eq(g(_, 2, _)(1, 3), [3, 2, 1]);
-    eq(g(_, _, 3)(1, 2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1, 2), [3, 2, 1]);
 
-    eq(g(1, _, _)(_, 3)(2), [3, 2, 1]);
-    eq(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
-    eq(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(_, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
 
-    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
-    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
   });
 
   it('should support @@functional/placeholder', function() {
@@ -77,29 +77,29 @@ describe('curryRightN', function() {
     const g = RA.curryRightN(3, f);
     const _ = { '@@functional/placeholder': true, x: Math.random() };
 
-    eq(g(1)(2)(3), [3, 2, 1]);
-    eq(g(1)(2, 3), [3, 2, 1]);
-    eq(g(1, 2)(3), [3, 2, 1]);
-    eq(g(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3), [3, 2, 1]);
 
-    eq(g(_, 2, 3)(1), [3, 2, 1]);
-    eq(g(1, _, 3)(2), [3, 2, 1]);
-    eq(g(1, 2, _)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, _)(3), [3, 2, 1]);
 
-    eq(g(1, _, _)(2)(3), [3, 2, 1]);
-    eq(g(_, 2, _)(1)(3), [3, 2, 1]);
-    eq(g(_, _, 3)(1)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1)(2), [3, 2, 1]);
 
-    eq(g(1, _, _)(2, 3), [3, 2, 1]);
-    eq(g(_, 2, _)(1, 3), [3, 2, 1]);
-    eq(g(_, _, 3)(1, 2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(1, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(1, 2), [3, 2, 1]);
 
-    eq(g(1, _, _)(_, 3)(2), [3, 2, 1]);
-    eq(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
-    eq(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, _, _)(_, 3)(2), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, 2, _)(_, 3)(1), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, 3)(_, 2)(1), [3, 2, 1]);
 
-    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
-    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(_, _)(_)(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [3, 2, 1]);
   });
 
   it('should forward extra arguments', function() {
@@ -108,10 +108,10 @@ describe('curryRightN', function() {
     };
     const g = RA.curryRightN(3, f);
 
-    eq(g(1, 2, 3), [3, 2, 1]);
-    eq(g(1, 2, 3, 4), [4, 3, 2, 1]);
-    eq(g(1, 2)(3, 4), [4, 3, 2, 1]);
-    eq(g(1)(2, 3, 4), [4, 3, 2, 1]);
-    eq(g(1)(2)(3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3), [3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2, 3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1, 2)(3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2, 3, 4), [4, 3, 2, 1]);
+    assert.sameOrderedMembers(g(1)(2)(3, 4), [4, 3, 2, 1]);
   });
 });

--- a/test/defaultWhen.js
+++ b/test/defaultWhen.js
@@ -1,20 +1,21 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('defaultWhen', function() {
   it('should return default value', function() {
-    eq(RA.defaultWhen(RA.isNull, 1, null), 1);
-    eq(RA.defaultWhen(RA.isString, 2, ''), 2);
+    assert.strictEqual(RA.defaultWhen(RA.isNull, 1, null), 1);
+    assert.strictEqual(RA.defaultWhen(RA.isString, 2, ''), 2);
   });
 
   it('should return value', function() {
-    eq(RA.defaultWhen(RA.isNull, 1, undefined), undefined);
-    eq(RA.defaultWhen(RA.isString, 2, 3), 3);
+    assert.isUndefined(RA.defaultWhen(RA.isNull, 1, undefined));
+    assert.strictEqual(RA.defaultWhen(RA.isString, 2, 3), 3);
   });
 
   it('should curry', function() {
-    eq(RA.defaultWhen(RA.isNull)(1)(null), 1);
-    eq(RA.defaultWhen(RA.isNull, 1)(null), 1);
-    eq(RA.defaultWhen(RA.isNull, 1, null), 1);
+    assert.strictEqual(RA.defaultWhen(RA.isNull)(1)(null), 1);
+    assert.strictEqual(RA.defaultWhen(RA.isNull, 1)(null), 1);
+    assert.strictEqual(RA.defaultWhen(RA.isNull, 1, null), 1);
   });
 });

--- a/test/dispatch.js
+++ b/test/dispatch.js
@@ -3,7 +3,6 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('dispatch', function() {
   it('should return first non-nil value', function() {
@@ -29,7 +28,7 @@ describe('dispatch', function() {
   it('should return curried function with max arity', function() {
     const fn = RA.dispatch([R.divide, R.identity]);
 
-    eq(fn.length, 2);
+    assert.strictEqual(fn.length, 2);
   });
 
   it('should act as switch', function() {
@@ -72,7 +71,7 @@ describe('dispatch', function() {
 
   context('given empty array provided as input', function() {
     specify('should return undefined', function() {
-      eq(RA.dispatch([]), undefined);
+      assert.isUndefined(RA.dispatch([]));
     });
   });
 
@@ -80,7 +79,7 @@ describe('dispatch', function() {
     specify('should return undefined', function() {
       const configuredDispatch = RA.dispatch([RA.stubUndefined, RA.stubNull]);
 
-      eq(configuredDispatch(), undefined);
+      assert.isUndefined(configuredDispatch());
     });
   });
 
@@ -90,7 +89,7 @@ describe('dispatch', function() {
       specify('should return undefined', function() {
         const configuredDispatch = RA.dispatch([() => {}, () => {}]);
 
-        eq(configuredDispatch(), undefined);
+        assert.isUndefined(configuredDispatch());
       });
     }
   );
@@ -98,6 +97,6 @@ describe('dispatch', function() {
   it('should support placeholder to specify "gaps"', function() {
     const dispatch = RA.dispatch(R.__);
 
-    eq(dispatch([RA.stubNull, R.always(1)])(), 1);
+    assert.strictEqual(dispatch([RA.stubNull, R.always(1)])(), 1);
   });
 });


### PR DESCRIPTION
Batch 2

test/

- contained.js
- curryRight.js
- curryRightN.js
- defaultWhen.js
- dispatch.js