### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#3

### DIFF
--- a/test/divideNum.js
+++ b/test/divideNum.js
@@ -1,17 +1,18 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('divideNum', function() {
   it('should divide the second number by the first number', function() {
-    eq(RA.divideNum(2, 1), 0.5);
-    eq(RA.divideNum(2.0, 1.0), 0.5);
-    eq(RA.divideNum(0, 2.0), Infinity);
-    eq(RA.divideNum(0.0, 2.0), Infinity);
-    eq(RA.divideNum(-0.0, 2.0), -Infinity);
+    assert.strictEqual(RA.divideNum(2, 1), 0.5);
+    assert.strictEqual(RA.divideNum(2.0, 1.0), 0.5);
+    assert.strictEqual(RA.divideNum(0, 2.0), Infinity);
+    assert.strictEqual(RA.divideNum(0.0, 2.0), Infinity);
+    assert.strictEqual(RA.divideNum(-0.0, 2.0), -Infinity);
   });
 
   it('should curry', function() {
-    eq(RA.divideNum(2)(1), 0.5);
-    eq(RA.divideNum(2, 1), 0.5);
+    assert.strictEqual(RA.divideNum(2)(1), 0.5);
+    assert.strictEqual(RA.divideNum(2, 1), 0.5);
   });
 });

--- a/test/dropArgs.js
+++ b/test/dropArgs.js
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
+import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('dropArgs', function() {
   let fn;
@@ -16,12 +16,12 @@ describe('dropArgs', function() {
     const actual = zeroArityFn('ignore1', 'ignore2');
     const expected = 3;
 
-    eq(actual, expected);
+    assert.strictEqual(actual, expected);
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const dropArgs = RA.dropArgs(R.__);
 
-    eq(dropArgs(fn)('ignore1', 'ignore2'), 3);
+    assert.strictEqual(dropArgs(fn)('ignore1', 'ignore2'), 3);
   });
 });

--- a/test/ensureArray.js
+++ b/test/ensureArray.js
@@ -2,24 +2,24 @@ import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('ensureArray', function() {
   context('given argument is not an array', function() {
     specify('should wrap value into singleton array', function() {
       const arrayPrototype = Array.prototype;
 
-      eq(RA.ensureArray(void 0), [void 0]);
-      eq(RA.ensureArray({}), [{}]);
-      eq(RA.ensureArray(null), [null]);
-      eq(RA.ensureArray(undefined), [undefined]);
-      eq(RA.ensureArray(42), [42]);
-      eq(RA.ensureArray('Array'), ['Array']);
-      eq(RA.ensureArray(true), [true]);
-      eq(RA.ensureArray(false), [false]);
-      eq(RA.ensureArray({ __proto__: arrayPrototype }), [
-        { __proto__: arrayPrototype },
-      ]);
+      assert.sameOrderedMembers(RA.ensureArray(void 0), [void 0]);
+      assert.sameDeepOrderedMembers(RA.ensureArray({}), [{}]);
+      assert.sameOrderedMembers(RA.ensureArray(null), [null]);
+      assert.sameOrderedMembers(RA.ensureArray(undefined), [undefined]);
+      assert.sameOrderedMembers(RA.ensureArray(42), [42]);
+      assert.sameOrderedMembers(RA.ensureArray('Array'), ['Array']);
+      assert.sameOrderedMembers(RA.ensureArray(true), [true]);
+      assert.sameOrderedMembers(RA.ensureArray(false), [false]);
+      assert.sameDeepOrderedMembers(
+        RA.ensureArray({ __proto__: arrayPrototype }),
+        [{ __proto__: arrayPrototype }]
+      );
     });
   });
 
@@ -90,6 +90,6 @@ describe('ensureArray', function() {
   it('should support placeholder to specify "gaps"', function() {
     const ensureArray = RA.ensureArray(R.__);
 
-    eq(ensureArray(1), [1]);
+    assert.sameOrderedMembers(ensureArray(1), [1]);
   });
 });

--- a/test/flattenPath.js
+++ b/test/flattenPath.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('flattenPath', function() {
   let path;
@@ -21,7 +22,7 @@ describe('flattenPath', function() {
           a: 1,
           b1: { b2: 999 },
         };
-        eq(RA.flattenPath(path, obj), obj);
+        assert.deepEqual(RA.flattenPath(path, obj), obj);
       }
     );
   });
@@ -30,13 +31,13 @@ describe('flattenPath', function() {
     specify(
       'should return object with identical structure as provided object',
       function() {
-        eq(RA.flattenPath(['does', 'not', 'exist'], obj), obj);
+        assert.deepEqual(RA.flattenPath(['does', 'not', 'exist'], obj), obj);
       }
     );
   });
 
   it('should curry', function() {
-    eq(RA.flattenPath([], {}), {});
-    eq(RA.flattenPath([])({}), {});
+    assert.deepEqual(RA.flattenPath([], {}), {});
+    assert.deepEqual(RA.flattenPath([])({}), {});
   });
 });

--- a/test/flattenProp.js
+++ b/test/flattenProp.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('flattenProp', function() {
   let prop;
@@ -17,7 +18,7 @@ describe('flattenProp', function() {
     specify(
       'should return object with identical structure as provided object',
       function() {
-        eq(RA.flattenProp('not_exist', obj), obj);
+        assert.deepEqual(RA.flattenProp('not_exist', obj), obj);
       }
     );
   });
@@ -30,7 +31,7 @@ describe('flattenProp', function() {
           a: 1,
           b: 999,
         };
-        eq(RA.flattenProp(prop, obj), obj);
+        assert.deepEqual(RA.flattenProp(prop, obj), obj);
       }
     );
   });
@@ -48,7 +49,7 @@ describe('flattenProp', function() {
         b: 999,
       };
 
-      eq(RA.flattenProp(prop, obj), expected);
+      assert.deepEqual(RA.flattenProp(prop, obj), expected);
     });
   });
 
@@ -60,11 +61,11 @@ describe('flattenProp', function() {
       b: { c: 3, d: 4 },
     };
 
-    eq(RA.flattenProp(prop, obj), expected);
+    assert.deepEqual(RA.flattenProp(prop, obj), expected);
   });
 
   it('should curry', function() {
-    eq(RA.flattenProp('prop', {}), {});
-    eq(RA.flattenProp('prop')({}), {});
+    assert.deepEqual(RA.flattenProp('prop', {}), {});
+    assert.deepEqual(RA.flattenProp('prop')({}), {});
   });
 });


### PR DESCRIPTION
test/

- divideNum.js
- dropArgs.js
- ensureArray.js
- flattenPath.js
- flattenProp.js
