### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#6

### DIFF
--- a/test/isFalsy.js
+++ b/test/isFalsy.js
@@ -1,45 +1,45 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isFalsy', function() {
   context('given falsy value', function() {
     specify('should return true', function() {
-      eq(RA.isFalsy(false), true);
-      eq(RA.isFalsy(0), true);
-      eq(RA.isFalsy(-0), true);
-      eq(RA.isFalsy(''), true);
-      eq(RA.isFalsy(null), true);
-      eq(RA.isFalsy(undefined), true);
-      eq(RA.isFalsy(NaN), true);
+      assert.isTrue(RA.isFalsy(false));
+      assert.isTrue(RA.isFalsy(0));
+      assert.isTrue(RA.isFalsy(-0));
+      assert.isTrue(RA.isFalsy(''));
+      assert.isTrue(RA.isFalsy(null));
+      assert.isTrue(RA.isFalsy(undefined));
+      assert.isTrue(RA.isFalsy(NaN));
     });
   });
 
   context('given truthy value', function() {
     specify('should return false', function() {
-      eq(RA.isFalsy('abc'), false);
-      eq(RA.isFalsy(Object('abc')), false);
-      eq(RA.isFalsy(args), false);
-      eq(RA.isFalsy([1, 2, 3]), false);
-      eq(RA.isFalsy(new Date()), false);
-      eq(RA.isFalsy(new Error()), false);
-      eq(RA.isFalsy(Array.prototype.slice), false);
-      eq(RA.isFalsy({ 0: 1, length: 1 }), false);
-      eq(RA.isFalsy(1), false);
-      eq(RA.isFalsy(/x/), false);
-      eq(RA.isFalsy(Symbol), RA.isUndefined(Symbol));
-      eq(RA.isFalsy({}), false);
-      eq(RA.isFalsy([]), false);
-      eq(RA.isFalsy(Infinity), false);
+      assert.isFalse(RA.isFalsy('abc'));
+      assert.isFalse(RA.isFalsy(Object('abc')));
+      assert.isFalse(RA.isFalsy(args));
+      assert.isFalse(RA.isFalsy([1, 2, 3]));
+      assert.isFalse(RA.isFalsy(new Date()));
+      assert.isFalse(RA.isFalsy(new Error()));
+      assert.isFalse(RA.isFalsy(Array.prototype.slice));
+      assert.isFalse(RA.isFalsy({ 0: 1, length: 1 }));
+      assert.isFalse(RA.isFalsy(1));
+      assert.isFalse(RA.isFalsy(/x/));
+      assert.strictEqual(RA.isFalsy(Symbol), RA.isUndefined(Symbol));
+      assert.isFalse(RA.isFalsy({}));
+      assert.isFalse(RA.isFalsy([]));
+      assert.isFalse(RA.isFalsy(Infinity));
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const isFalsy = RA.isFalsy(R.__);
 
-    eq(isFalsy(null), true);
+    assert.isTrue(isFalsy(null));
   });
 });

--- a/test/isFinite.js
+++ b/test/isFinite.js
@@ -1,49 +1,49 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
 import polyfill from '../src/internal/polyfills/Number.isFinite';
-import eq from './shared/eq';
 
 describe('isFinite', function() {
   it('should test value for a finite `Number`', function() {
-    eq(RA.isFinite(Infinity), false);
-    eq(RA.isFinite(NaN), false);
-    eq(RA.isFinite(-Infinity), false);
+    assert.isFalse(RA.isFinite(Infinity));
+    assert.isFalse(RA.isFinite(NaN));
+    assert.isFalse(RA.isFinite(-Infinity));
 
-    eq(RA.isFinite(0), true);
-    eq(RA.isFinite(-0), true);
-    eq(RA.isFinite(2e64), true);
-    eq(RA.isFinite(324234), true);
-    eq(RA.isFinite(1.2342), true);
+    assert.isTrue(RA.isFinite(0));
+    assert.isTrue(RA.isFinite(-0));
+    assert.isTrue(RA.isFinite(2e64));
+    assert.isTrue(RA.isFinite(324234));
+    assert.isTrue(RA.isFinite(1.2342));
 
     // Would've been true with global isFinite('0').
-    eq(RA.isFinite('0'), false);
+    assert.isFalse(RA.isFinite('0'));
 
     // Would've been true with global isFinite(null).
-    eq(RA.isFinite(null), false);
+    assert.isFalse(RA.isFinite(null));
   });
 
   it('should test polyfill for a finite `Number', function() {
-    eq(polyfill(Infinity), false);
-    eq(polyfill(NaN), false);
-    eq(polyfill(-Infinity), false);
+    assert.isFalse(polyfill(Infinity));
+    assert.isFalse(polyfill(NaN));
+    assert.isFalse(polyfill(-Infinity));
 
-    eq(polyfill(0), true);
-    eq(polyfill(-0), true);
-    eq(polyfill(2e64), true);
-    eq(polyfill(324234), true);
-    eq(polyfill(1.2342), true);
+    assert.isTrue(polyfill(0));
+    assert.isTrue(polyfill(-0));
+    assert.isTrue(polyfill(2e64));
+    assert.isTrue(polyfill(324234));
+    assert.isTrue(polyfill(1.2342));
 
     // Would've been true with global isFinite('0').
-    eq(polyfill('0'), false);
+    assert.isFalse(polyfill('0'));
 
     // Would've been true with global isFinite(null).
-    eq(polyfill(null), false);
+    assert.isFalse(polyfill(null));
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const isFinite = RA.isFinite(R.__);
 
-    eq(isFinite(1), true);
+    assert.isTrue(isFinite(1));
   });
 });

--- a/test/isFloat.js
+++ b/test/isFloat.js
@@ -1,48 +1,48 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 
 describe('isFloat', function() {
   context('given float number', function() {
     specify('should return true', function() {
-      eq(RA.isFloat(0.1), true);
-      eq(RA.isFloat(Math.PI), true);
+      assert.isTrue(RA.isFloat(0.1));
+      assert.isTrue(RA.isFloat(Math.PI));
       // prettier-ignore
-      eq(RA.isFloat(5.56789+0), true);
+      assert.isTrue(RA.isFloat(5.56789+0));
     });
   });
 
   context('given non float number', function() {
     specify('should return false', function() {
-      eq(RA.isFloat(0), false);
-      eq(RA.isFloat(1), false);
-      eq(RA.isFloat(-100000), false);
-      eq(RA.isFloat(MAX_SAFE_INTEGER), false);
-      eq(RA.isFloat(MIN_SAFE_INTEGER), false);
+      assert.isFalse(RA.isFloat(0));
+      assert.isFalse(RA.isFloat(1));
+      assert.isFalse(RA.isFloat(-100000));
+      assert.isFalse(RA.isFloat(MAX_SAFE_INTEGER));
+      assert.isFalse(RA.isFloat(MIN_SAFE_INTEGER));
       // prettier-ignore
-      eq(RA.isFloat(5e+0), false);
-      eq(RA.isFloat(NaN), false);
-      eq(RA.isFloat(Infinity), false);
-      eq(RA.isFloat(-Infinity), false);
-      eq(RA.isFloat('10'), false);
-      eq(RA.isFloat(true), false);
-      eq(RA.isFloat(false), false);
-      eq(RA.isFloat([1]), false);
+      assert.isFalse(RA.isFloat(5e+0));
+      assert.isFalse(RA.isFloat(NaN));
+      assert.isFalse(RA.isFloat(Infinity));
+      assert.isFalse(RA.isFloat(-Infinity));
+      assert.isFalse(RA.isFloat('10'));
+      assert.isFalse(RA.isFloat(true));
+      assert.isFalse(RA.isFloat(false));
+      assert.isFalse(RA.isFloat([1]));
     });
   });
 
   context('given a number that looks like a float number', function() {
     specify('should treat the number as integer', function() {
-      eq(RA.isFloat(1.0), false);
+      assert.isFalse(RA.isFloat(1.0));
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const isFloat = RA.isFloat(R.__);
 
-    eq(isFloat(1.2), true);
+    assert.isTrue(isFloat(1.2));
   });
 });

--- a/test/isFunction.js
+++ b/test/isFunction.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 import genFunc from './shared/genFunc';
@@ -9,25 +9,28 @@ import asyncFunc from './shared/asyncFunc';
 
 describe('isFunction', function() {
   it('should test value for a `Function`', function() {
-    eq(RA.isFunction(genFunc), typeof genFunc === 'function');
-    eq(RA.isFunction(asyncFunc), typeof asyncFunc === 'function');
-    eq(RA.isFunction(Symbol), typeof Symbol === 'function');
-    eq(RA.isFunction(() => {}), true);
-    eq(RA.isFunction(function() {}), true);
-    eq(RA.isFunction(Array.prototype.slice), true);
-    eq(RA.isFunction(args), false);
-    eq(RA.isFunction([1, 2, 3]), false);
-    eq(RA.isFunction(true), false);
-    eq(RA.isFunction(new Date()), false);
-    eq(RA.isFunction(new Error()), false);
-    eq(RA.isFunction({ 0: 1, length: 1 }), false);
-    eq(RA.isFunction(1), false);
-    eq(RA.isFunction(/x/), false);
+    assert.strictEqual(RA.isFunction(genFunc), typeof genFunc === 'function');
+    assert.strictEqual(
+      RA.isFunction(asyncFunc),
+      typeof asyncFunc === 'function'
+    );
+    assert.strictEqual(RA.isFunction(Symbol), typeof Symbol === 'function');
+    assert.isTrue(RA.isFunction(() => {}));
+    assert.isTrue(RA.isFunction(function() {}));
+    assert.isTrue(RA.isFunction(Array.prototype.slice));
+    assert.isFalse(RA.isFunction(args));
+    assert.isFalse(RA.isFunction([1, 2, 3]));
+    assert.isFalse(RA.isFunction(true));
+    assert.isFalse(RA.isFunction(new Date()));
+    assert.isFalse(RA.isFunction(new Error()));
+    assert.isFalse(RA.isFunction({ 0: 1, length: 1 }));
+    assert.isFalse(RA.isFunction(1));
+    assert.isFalse(RA.isFunction(/x/));
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const isFunction = RA.isFunction(R.__);
 
-    eq(isFunction(genFunc), typeof genFunc === 'function');
+    assert.strictEqual(isFunction(genFunc), typeof genFunc === 'function');
   });
 });

--- a/test/isGeneratorFunction.js
+++ b/test/isGeneratorFunction.js
@@ -1,29 +1,35 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 import genFunc from './shared/genFunc';
 
 describe('isGeneratorFunction', function() {
   it('should tests value for a `Generator Function`', function() {
-    eq(RA.isGeneratorFunction(genFunc), typeof genFunc === 'function');
-    eq(RA.isGeneratorFunction(args), false);
-    eq(RA.isGeneratorFunction([1, 2, 3]), false);
-    eq(RA.isGeneratorFunction(true), false);
-    eq(RA.isGeneratorFunction(new Date()), false);
-    eq(RA.isGeneratorFunction(new Error()), false);
-    eq(RA.isGeneratorFunction(Array.prototype.slice), false);
-    eq(RA.isGeneratorFunction({ 0: 1, length: 1 }), false);
-    eq(RA.isGeneratorFunction(1), false);
-    eq(RA.isGeneratorFunction(/x/), false);
-    eq(RA.isGeneratorFunction(Symbol), false);
+    assert.strictEqual(
+      RA.isGeneratorFunction(genFunc),
+      typeof genFunc === 'function'
+    );
+    assert.isFalse(RA.isGeneratorFunction(args));
+    assert.isFalse(RA.isGeneratorFunction([1, 2, 3]));
+    assert.isFalse(RA.isGeneratorFunction(true));
+    assert.isFalse(RA.isGeneratorFunction(new Date()));
+    assert.isFalse(RA.isGeneratorFunction(new Error()));
+    assert.isFalse(RA.isGeneratorFunction(Array.prototype.slice));
+    assert.isFalse(RA.isGeneratorFunction({ 0: 1, length: 1 }));
+    assert.isFalse(RA.isGeneratorFunction(1));
+    assert.isFalse(RA.isGeneratorFunction(/x/));
+    assert.isFalse(RA.isGeneratorFunction(Symbol));
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const isGeneratorFunction = RA.isGeneratorFunction(R.__);
 
-    eq(isGeneratorFunction(genFunc), typeof genFunc === 'function');
+    assert.strictEqual(
+      isGeneratorFunction(genFunc),
+      typeof genFunc === 'function'
+    );
   });
 });

--- a/test/isInteger.js
+++ b/test/isInteger.js
@@ -1,70 +1,70 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import { isIntegerPolyfill } from '../src/isInteger';
 
 describe('isInteger', function() {
   it('should test value for an `integer`', function() {
-    eq(RA.isInteger(0), true);
-    eq(RA.isInteger(1), true);
-    eq(RA.isInteger(-100000), true);
-    eq(RA.isInteger(MAX_SAFE_INTEGER), true);
-    eq(RA.isInteger(MIN_SAFE_INTEGER), true);
-    eq(RA.isInteger(5), true);
+    assert.isTrue(RA.isInteger(0));
+    assert.isTrue(RA.isInteger(1));
+    assert.isTrue(RA.isInteger(-100000));
+    assert.isTrue(RA.isInteger(MAX_SAFE_INTEGER));
+    assert.isTrue(RA.isInteger(MIN_SAFE_INTEGER));
+    assert.isTrue(RA.isInteger(5));
 
-    eq(RA.isInteger(0.1), false);
-    eq(RA.isInteger(Math.PI), false);
-    eq(RA.isInteger(5.56789), false);
+    assert.isFalse(RA.isInteger(0.1));
+    assert.isFalse(RA.isInteger(Math.PI));
+    assert.isFalse(RA.isInteger(5.56789));
 
-    eq(RA.isInteger(NaN), false);
-    eq(RA.isInteger(Infinity), false);
-    eq(RA.isInteger(-Infinity), false);
-    eq(RA.isInteger('10'), false);
-    eq(RA.isInteger(true), false);
-    eq(RA.isInteger(false), false);
-    eq(RA.isInteger([1]), false);
+    assert.isFalse(RA.isInteger(NaN));
+    assert.isFalse(RA.isInteger(Infinity));
+    assert.isFalse(RA.isInteger(-Infinity));
+    assert.isFalse(RA.isInteger('10'));
+    assert.isFalse(RA.isInteger(true));
+    assert.isFalse(RA.isInteger(false));
+    assert.isFalse(RA.isInteger([1]));
   });
 
   context('isIntegerPolyfill', function() {
     specify('should test polyfill for an `integer', function() {
-      eq(isIntegerPolyfill(0), true);
-      eq(isIntegerPolyfill(1), true);
-      eq(isIntegerPolyfill(-100000), true);
-      eq(isIntegerPolyfill(MAX_SAFE_INTEGER), true);
-      eq(isIntegerPolyfill(MIN_SAFE_INTEGER), true);
+      assert.isTrue(isIntegerPolyfill(0));
+      assert.isTrue(isIntegerPolyfill(1));
+      assert.isTrue(isIntegerPolyfill(-100000));
+      assert.isTrue(isIntegerPolyfill(MAX_SAFE_INTEGER));
+      assert.isTrue(isIntegerPolyfill(MIN_SAFE_INTEGER));
 
-      eq(isIntegerPolyfill(0.1), false);
-      eq(isIntegerPolyfill(Math.PI), false);
-      eq(isIntegerPolyfill(5.56789), false);
+      assert.isFalse(isIntegerPolyfill(0.1));
+      assert.isFalse(isIntegerPolyfill(Math.PI));
+      assert.isFalse(isIntegerPolyfill(5.56789));
 
-      eq(isIntegerPolyfill(NaN), false);
-      eq(isIntegerPolyfill(Infinity), false);
-      eq(isIntegerPolyfill(-Infinity), false);
-      eq(isIntegerPolyfill('10'), false);
-      eq(isIntegerPolyfill(true), false);
-      eq(isIntegerPolyfill(false), false);
-      eq(isIntegerPolyfill([1]), false);
+      assert.isFalse(isIntegerPolyfill(NaN));
+      assert.isFalse(isIntegerPolyfill(Infinity));
+      assert.isFalse(isIntegerPolyfill(-Infinity));
+      assert.isFalse(isIntegerPolyfill('10'));
+      assert.isFalse(isIntegerPolyfill(true));
+      assert.isFalse(isIntegerPolyfill(false));
+      assert.isFalse(isIntegerPolyfill([1]));
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const isIntegerPolyfillWithGap = isIntegerPolyfill(R.__);
 
-      eq(isIntegerPolyfillWithGap(1), true);
+      assert.isTrue(isIntegerPolyfillWithGap(1));
     });
   });
 
   context('given a number that looks like a float number', function() {
     specify('should treat the number as integer', function() {
-      eq(RA.isInteger(1.0), true);
+      assert.isTrue(RA.isInteger(1.0));
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const isInteger = RA.isInteger(R.__);
 
-    eq(isInteger(1), true);
+    assert.isTrue(isInteger(1));
   });
 });

--- a/test/isNegative.js
+++ b/test/isNegative.js
@@ -4,41 +4,40 @@ import * as R from 'ramda';
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNegative', function() {
   it('should test value for a negative `Number`', function() {
-    eq(RA.isNegative(0), false);
-    eq(RA.isNegative(-0.1), true);
-    eq(RA.isNegative(Object(0)), false);
-    eq(RA.isNegative(Object(-0.1)), true);
-    eq(RA.isNegative(NaN), false);
-    eq(RA.isNegative(Infinity), false);
-    eq(RA.isNegative(-Infinity), true);
-    eq(RA.isNegative(MAX_SAFE_INTEGER), false);
-    eq(RA.isNegative(MIN_SAFE_INTEGER), true);
-    eq(RA.isNegative(Number.MAX_VALUE), false);
-    eq(RA.isNegative(Number.MIN_VALUE), false);
+    assert.isFalse(RA.isNegative(0));
+    assert.isTrue(RA.isNegative(-0.1));
+    assert.isFalse(RA.isNegative(Object(0)));
+    assert.isTrue(RA.isNegative(Object(-0.1)));
+    assert.isFalse(RA.isNegative(NaN));
+    assert.isFalse(RA.isNegative(Infinity));
+    assert.isTrue(RA.isNegative(-Infinity));
+    assert.isFalse(RA.isNegative(MAX_SAFE_INTEGER));
+    assert.isTrue(RA.isNegative(MIN_SAFE_INTEGER));
+    assert.isFalse(RA.isNegative(Number.MAX_VALUE));
+    assert.isFalse(RA.isNegative(Number.MIN_VALUE));
 
-    eq(RA.isNegative(new Date()), false);
-    eq(RA.isNegative(args), false);
-    eq(RA.isNegative([1, 2, 3]), false);
-    eq(RA.isNegative(Object(false)), false);
-    eq(RA.isNegative(new Error()), false);
-    eq(RA.isNegative(RA), false);
-    eq(RA.isNegative(Array.prototype.slice), false);
-    eq(RA.isNegative({ a: 1 }), false);
-    eq(RA.isNegative(/x/), false);
-    eq(RA.isNegative(Object('a')), false);
+    assert.isFalse(RA.isNegative(new Date()));
+    assert.isFalse(RA.isNegative(args));
+    assert.isFalse(RA.isNegative([1, 2, 3]));
+    assert.isFalse(RA.isNegative(Object(false)));
+    assert.isFalse(RA.isNegative(new Error()));
+    assert.isFalse(RA.isNegative(RA));
+    assert.isFalse(RA.isNegative(Array.prototype.slice));
+    assert.isFalse(RA.isNegative({ a: 1 }));
+    assert.isFalse(RA.isNegative(/x/));
+    assert.isFalse(RA.isNegative(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isNegative(Symbol), false);
+      assert.isFalse(RA.isNegative(Symbol));
     }
 
-    eq(RA.isNegative(null), false);
-    eq(RA.isNegative(undefined), false);
+    assert.isFalse(RA.isNegative(null));
+    assert.isFalse(RA.isNegative(undefined));
   });
 
   it('should support placeholder to specify "gaps"', function() {


### PR DESCRIPTION
Batch 6
test/

- isFalsy.js
- isFinite.js
- isFloat.js
- isFunction.js
- isGeneratorFunction.js
- isInteger.js
- isNegative.js