### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#7

### DIFF
--- a/test/isNotGeneratorFunction.js
+++ b/test/isNotGeneratorFunction.js
@@ -2,7 +2,6 @@ import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 import genFunc from './shared/genFunc';
@@ -29,6 +28,9 @@ describe('isNotGeneratorFunction', function() {
   it('should support placeholder to specify "gaps"', function() {
     const isNotGeneratorFunction = RA.isNotGeneratorFunction(R.__);
 
-    eq(isNotGeneratorFunction(genFunc), typeof genFunc !== 'function');
+    assert.strictEqual(
+      isNotGeneratorFunction(genFunc),
+      typeof genFunc !== 'function'
+    );
   });
 });

--- a/test/isNotNil.js
+++ b/test/isNotNil.js
@@ -1,13 +1,14 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isNotNil', function() {
   it('tests a value for complement of `null` or `undefined`', function() {
-    eq(RA.isNotNil(void 0), false);
-    eq(RA.isNotNil(null), false);
-    eq(RA.isNotNil([]), true);
-    eq(RA.isNotNil({}), true);
-    eq(RA.isNotNil(0), true);
-    eq(RA.isNotNil(''), true);
+    assert.isFalse(RA.isNotNil(void 0));
+    assert.isFalse(RA.isNotNil(null));
+    assert.isTrue(RA.isNotNil([]));
+    assert.isTrue(RA.isNotNil({}));
+    assert.isTrue(RA.isNotNil(0));
+    assert.isTrue(RA.isNotNil(''));
   });
 });

--- a/test/isNotNull.js
+++ b/test/isNotNull.js
@@ -1,13 +1,14 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isNotNull', function() {
   it('tests a value for complement of `null`', function() {
-    eq(RA.isNotNull(void 0), true);
-    eq(RA.isNotNull(null), false);
-    eq(RA.isNotNull([]), true);
-    eq(RA.isNotNull({}), true);
-    eq(RA.isNotNull(0), true);
-    eq(RA.isNotNull(''), true);
+    assert.isTrue(RA.isNotNull(void 0));
+    assert.isFalse(RA.isNotNull(null));
+    assert.isTrue(RA.isNotNull([]));
+    assert.isTrue(RA.isNotNull({}));
+    assert.isTrue(RA.isNotNull(0));
+    assert.isTrue(RA.isNotNull(''));
   });
 });

--- a/test/isNotNumber.js
+++ b/test/isNotNumber.js
@@ -1,40 +1,41 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNotNumber', function() {
   it('tests a value for complement of `Number`', function() {
-    eq(RA.isNotNumber(0), false);
-    eq(RA.isNotNumber(0.1), false);
-    eq(RA.isNotNumber(Object(0)), false);
-    eq(RA.isNotNumber(Object(0.1)), false);
-    eq(RA.isNotNumber(NaN), false);
-    eq(RA.isNotNumber(Infinity), false);
-    eq(RA.isNotNumber(-Infinity), false);
-    eq(RA.isNotNumber(MAX_SAFE_INTEGER), false);
-    eq(RA.isNotNumber(MIN_SAFE_INTEGER), false);
-    eq(RA.isNotNumber(Number.MAX_VALUE), false);
-    eq(RA.isNotNumber(Number.MIN_VALUE), false);
+    assert.isFalse(RA.isNotNumber(0));
+    assert.isFalse(RA.isNotNumber(0.1));
+    assert.isFalse(RA.isNotNumber(Object(0)));
+    assert.isFalse(RA.isNotNumber(Object(0.1)));
+    assert.isFalse(RA.isNotNumber(NaN));
+    assert.isFalse(RA.isNotNumber(Infinity));
+    assert.isFalse(RA.isNotNumber(-Infinity));
+    assert.isFalse(RA.isNotNumber(MAX_SAFE_INTEGER));
+    assert.isFalse(RA.isNotNumber(MIN_SAFE_INTEGER));
+    assert.isFalse(RA.isNotNumber(Number.MAX_VALUE));
+    assert.isFalse(RA.isNotNumber(Number.MIN_VALUE));
 
-    eq(RA.isNotNumber(new Date()), true);
-    eq(RA.isNotNumber(args), true);
-    eq(RA.isNotNumber([1, 2, 3]), true);
-    eq(RA.isNotNumber(Object(true)), true);
-    eq(RA.isNotNumber(new Error()), true);
-    eq(RA.isNotNumber(RA), true);
-    eq(RA.isNotNumber(Array.prototype.slice), true);
-    eq(RA.isNotNumber({ a: 1 }), true);
-    eq(RA.isNotNumber(/x/), true);
-    eq(RA.isNotNumber(Object('a')), true);
+    assert.isTrue(RA.isNotNumber(new Date()));
+    assert.isTrue(RA.isNotNumber(args));
+    assert.isTrue(RA.isNotNumber([1, 2, 3]));
+    assert.isTrue(RA.isNotNumber(Object(true)));
+    assert.isTrue(RA.isNotNumber(new Error()));
+    assert.isTrue(RA.isNotNumber(RA));
+    assert.isTrue(RA.isNotNumber(Array.prototype.slice));
+    assert.isTrue(RA.isNotNumber({ a: 1 }));
+    assert.isTrue(RA.isNotNumber(/x/));
+    assert.isTrue(RA.isNotNumber(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isNotNumber(Symbol), true);
+      assert.isTrue(RA.isNotNumber(Symbol));
     }
 
-    eq(RA.isNotNumber(null), true);
-    eq(RA.isNotNumber(undefined), true);
+    assert.isTrue(RA.isNotNumber(null));
+    assert.isTrue(RA.isNotNumber(undefined));
   });
 });

--- a/test/isNotObj.js
+++ b/test/isNotObj.js
@@ -1,33 +1,34 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNotObj', function() {
   it('tests a value for complement of language type of `Object`', function() {
-    eq(RA.isNotObj({}), false);
-    eq(RA.isNotObj(Object(false)), false);
-    eq(RA.isNotObj(Object.create(null)), false);
-    eq(RA.isNotObj(args), false);
-    eq(RA.isNotObj([1, 2, 3]), false);
-    eq(RA.isNotObj(Object(false)), false);
-    eq(RA.isNotObj(new Date()), false);
-    eq(RA.isNotObj(new Error()), false);
-    eq(RA.isNotObj(RA), false);
-    eq(RA.isNotObj(Array.prototype.slice), false);
-    eq(RA.isNotObj({ a: 1 }), false);
-    eq(RA.isNotObj(Object(0)), false);
-    eq(RA.isNotObj(/x/), false);
-    eq(RA.isNotObj(Object('a')), false);
-    eq(RA.isNotObj(Symbol), typeof Symbol === 'undefined');
+    assert.isFalse(RA.isNotObj({}));
+    assert.isFalse(RA.isNotObj(Object(false)));
+    assert.isFalse(RA.isNotObj(Object.create(null)));
+    assert.isFalse(RA.isNotObj(args));
+    assert.isFalse(RA.isNotObj([1, 2, 3]));
+    assert.isFalse(RA.isNotObj(Object(false)));
+    assert.isFalse(RA.isNotObj(new Date()));
+    assert.isFalse(RA.isNotObj(new Error()));
+    assert.isFalse(RA.isNotObj(RA));
+    assert.isFalse(RA.isNotObj(Array.prototype.slice));
+    assert.isFalse(RA.isNotObj({ a: 1 }));
+    assert.isFalse(RA.isNotObj(Object(0)));
+    assert.isFalse(RA.isNotObj(/x/));
+    assert.isFalse(RA.isNotObj(Object('a')));
+    assert.strictEqual(RA.isNotObj(Symbol), typeof Symbol === 'undefined');
 
-    eq(RA.isNotObj(null), true);
-    eq(RA.isNotObj(undefined), true);
+    assert.isTrue(RA.isNotObj(null));
+    assert.isTrue(RA.isNotObj(undefined));
   });
 });
 
 describe('isNotObject', function() {
   it('tests an alias', function() {
-    eq(RA.isNotObj === RA.isNotObject, true);
+    assert.isTrue(RA.isNotObj === RA.isNotObject);
   });
 });

--- a/test/isNotObj.js
+++ b/test/isNotObj.js
@@ -29,6 +29,6 @@ describe('isNotObj', function() {
 
 describe('isNotObject', function() {
   it('tests an alias', function() {
-    assert.isTrue(RA.isNotObj === RA.isNotObject);
+    assert.strictEqual(RA.isNotObj, RA.isNotObject);
   });
 });

--- a/test/isNotObjLike.js
+++ b/test/isNotObjLike.js
@@ -1,32 +1,33 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNotObjLike', function() {
   it('tests a value for non object-like interface', function() {
-    eq(RA.isNotObjLike({}), false);
-    eq(RA.isNotObjLike(Object(false)), false);
-    eq(RA.isNotObjLike(args), false);
-    eq(RA.isNotObjLike([1, 2, 3]), false);
-    eq(RA.isNotObjLike(Object(false)), false);
-    eq(RA.isNotObjLike(new Date()), false);
-    eq(RA.isNotObjLike(new Error()), false);
-    eq(RA.isNotObjLike(RA), false);
-    eq(RA.isNotObjLike({ a: 1 }), false);
-    eq(RA.isNotObjLike(Object(0)), false);
-    eq(RA.isNotObjLike(/x/), false);
-    eq(RA.isNotObjLike(Object('a')), false);
+    assert.isFalse(RA.isNotObjLike({}));
+    assert.isFalse(RA.isNotObjLike(Object(false)));
+    assert.isFalse(RA.isNotObjLike(args));
+    assert.isFalse(RA.isNotObjLike([1, 2, 3]));
+    assert.isFalse(RA.isNotObjLike(Object(false)));
+    assert.isFalse(RA.isNotObjLike(new Date()));
+    assert.isFalse(RA.isNotObjLike(new Error()));
+    assert.isFalse(RA.isNotObjLike(RA));
+    assert.isFalse(RA.isNotObjLike({ a: 1 }));
+    assert.isFalse(RA.isNotObjLike(Object(0)));
+    assert.isFalse(RA.isNotObjLike(/x/));
+    assert.isFalse(RA.isNotObjLike(Object('a')));
 
-    eq(RA.isNotObjLike(Symbol), true);
-    eq(RA.isNotObjLike(Array.prototype.slice), true);
-    eq(RA.isNotObjLike(null), true);
-    eq(RA.isNotObjLike(undefined), true);
+    assert.isTrue(RA.isNotObjLike(Symbol));
+    assert.isTrue(RA.isNotObjLike(Array.prototype.slice));
+    assert.isTrue(RA.isNotObjLike(null));
+    assert.isTrue(RA.isNotObjLike(undefined));
   });
 });
 
 describe('isNotObjectLike', function() {
   it('tests an alias', function() {
-    eq(RA.isNotObjLike === RA.isNotObjectLike, true);
+    assert.isTrue(RA.isNotObjLike === RA.isNotObjectLike);
   });
 });

--- a/test/isNotPair.js
+++ b/test/isNotPair.js
@@ -1,19 +1,20 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isNotPair', function() {
   it('tests a value for complement of pair', function() {
-    eq(RA.isNotPair([]), true);
-    eq(RA.isNotPair([0]), true);
-    eq(RA.isNotPair([0, 1]), false);
-    eq(RA.isNotPair([0, 1, 2]), true);
-    eq(RA.isNotPair(0), true);
-    eq(RA.isNotPair(''), true);
-    eq(RA.isNotPair('foo'), true);
-    eq(RA.isNotPair(false), true);
-    eq(RA.isNotPair(true), true);
-    eq(RA.isNotPair(new Date()), true);
-    eq(RA.isNotPair({ 0: 0, 1: 1 }), true);
-    eq(RA.isNotPair({ foo: 0, bar: 1 }), true);
+    assert.isTrue(RA.isNotPair([]));
+    assert.isTrue(RA.isNotPair([0]));
+    assert.isFalse(RA.isNotPair([0, 1]));
+    assert.isTrue(RA.isNotPair([0, 1, 2]));
+    assert.isTrue(RA.isNotPair(0));
+    assert.isTrue(RA.isNotPair(''));
+    assert.isTrue(RA.isNotPair('foo'));
+    assert.isTrue(RA.isNotPair(false));
+    assert.isTrue(RA.isNotPair(true));
+    assert.isTrue(RA.isNotPair(new Date()));
+    assert.isTrue(RA.isNotPair({ 0: 0, 1: 1 }));
+    assert.isTrue(RA.isNotPair({ foo: 0, bar: 1 }));
   });
 });


### PR DESCRIPTION
Batch 7

test/

- isNotGeneratorFunction.js
- isNotNil.js
- isNotNull.js
- isNotNumber.js
- isNotObj.js
- isNotObjLike.js
- isNotPair.js
