### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#8

### DIFF
--- a/test/isNotPlainObj.js
+++ b/test/isNotPlainObj.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import element from './shared/element';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
@@ -12,53 +13,53 @@ class Bar {
 
 describe('isNotPlainObj', function() {
   it('tests a value for POJO', function() {
-    eq(RA.isNotPlainObj({}), false);
-    eq(RA.isNotPlainObj({ prop: 'value' }), false);
-    eq(RA.isNotPlainObj({ constructor: Bar }), false);
-    eq(RA.isNotPlainObj(new Bar()), true);
-    eq(RA.isNotPlainObj(['a', 'b', 'c']), true);
+    assert.isFalse(RA.isNotPlainObj({}));
+    assert.isFalse(RA.isNotPlainObj({ prop: 'value' }));
+    assert.isFalse(RA.isNotPlainObj({ constructor: Bar }));
+    assert.isTrue(RA.isNotPlainObj(new Bar()));
+    assert.isTrue(RA.isNotPlainObj(['a', 'b', 'c']));
   });
 
   it('tests a value with prototype of null', function() {
-    eq(RA.isNotPlainObj(Object.create(null)), false);
+    assert.isFalse(RA.isNotPlainObj(Object.create(null)));
 
     const object = Object.create(null);
     object.constructor = Object.prototype.constructor;
 
-    eq(RA.isNotPlainObj(object), false);
+    assert.isFalse(RA.isNotPlainObj(object));
   });
 
   it('tests a value with `valueOf` property', function() {
-    eq(RA.isNotPlainObj({ valueOf: 1 }), false);
+    assert.isFalse(RA.isNotPlainObj({ valueOf: 1 }));
   });
 
   it('test a value with custom prototype', function() {
-    eq(RA.isNotPlainObj(Object.create({ a: 3 })), false);
+    assert.isFalse(RA.isNotPlainObj(Object.create({ a: 3 })));
   });
 
   it('test a value that is DOM element', function() {
     if (element) {
-      eq(RA.isNotPlainObj(element), true);
+      assert.isTrue(RA.isNotPlainObj(element));
     }
   });
 
   it('test a value for non-objects', function() {
-    eq(RA.isNotPlainObj(args), true);
-    eq(RA.isNotPlainObj(Error), true);
-    eq(RA.isNotPlainObj(Math), true);
-    eq(RA.isNotPlainObj(true), true);
-    eq(RA.isNotPlainObj('abc'), true);
+    assert.isTrue(RA.isNotPlainObj(args));
+    assert.isTrue(RA.isNotPlainObj(Error));
+    assert.isTrue(RA.isNotPlainObj(Math));
+    assert.isTrue(RA.isNotPlainObj(true));
+    assert.isTrue(RA.isNotPlainObj('abc'));
   });
 
   it('test a value for Symbol', function() {
     if (Symbol) {
-      eq(RA.isNotPlainObj(Symbol.for('symbol')), true);
+      assert.isTrue(RA.isNotPlainObj(Symbol.for('symbol')));
     }
   });
 });
 
 describe('isNotPlainObject', function() {
   it('tests an alias', function() {
-    eq(RA.isNotPlainObj === RA.isNotPlainObject, true);
+    assert.strictEqual(RA.isNotPlainObj, RA.isNotPlainObject);
   });
 });

--- a/test/isNotRegExp.js
+++ b/test/isNotRegExp.js
@@ -1,32 +1,33 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNotRegExp', function() {
   it('tests a value for complement of `RegExp`', function() {
-    eq(RA.isNotRegExp('a'), true);
-    eq(RA.isNotRegExp(1), true);
-    eq(RA.isNotRegExp([]), true);
-    eq(RA.isNotRegExp({}), true);
-    eq(RA.isNotRegExp(true), true);
-    eq(RA.isNotRegExp(false), true);
-    eq(RA.isNotRegExp(new Error()), true);
-    eq(RA.isNotRegExp(new Date()), true);
-    eq(RA.isNotRegExp(RA), true);
-    eq(RA.isNotRegExp(function() {}), true);
-    eq(RA.isNotRegExp(Object(0)), true);
-    eq(RA.isNotRegExp(Object('a')), true);
-    eq(RA.isNotRegExp(args), true);
+    assert.isTrue(RA.isNotRegExp('a'));
+    assert.isTrue(RA.isNotRegExp(1));
+    assert.isTrue(RA.isNotRegExp([]));
+    assert.isTrue(RA.isNotRegExp({}));
+    assert.isTrue(RA.isNotRegExp(true));
+    assert.isTrue(RA.isNotRegExp(false));
+    assert.isTrue(RA.isNotRegExp(new Error()));
+    assert.isTrue(RA.isNotRegExp(new Date()));
+    assert.isTrue(RA.isNotRegExp(RA));
+    assert.isTrue(RA.isNotRegExp(function() {}));
+    assert.isTrue(RA.isNotRegExp(Object(0)));
+    assert.isTrue(RA.isNotRegExp(Object('a')));
+    assert.isTrue(RA.isNotRegExp(args));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isNotRegExp(Symbol), true);
+      assert.isTrue(RA.isNotRegExp(Symbol));
     }
 
-    eq(RA.isNotRegExp(null), true);
-    eq(RA.isNotRegExp(undefined), true);
+    assert.isTrue(RA.isNotRegExp(null));
+    assert.isTrue(RA.isNotRegExp(undefined));
 
-    eq(RA.isNotRegExp(new RegExp()), false);
-    eq(RA.isNotRegExp(/(?:)/), false);
+    assert.isFalse(RA.isNotRegExp(new RegExp()));
+    assert.isFalse(RA.isNotRegExp(/(?:)/));
   });
 });

--- a/test/isNotString.js
+++ b/test/isNotString.js
@@ -1,22 +1,23 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isNotString', function() {
   it('tests a value for complement of `String`', function() {
-    eq(RA.isNotString('abc'), false);
-    eq(RA.isNotString(Object('abc')), false);
+    assert.isFalse(RA.isNotString('abc'));
+    assert.isFalse(RA.isNotString(Object('abc')));
 
-    eq(RA.isNotString(args), true);
-    eq(RA.isNotString([1, 2, 3]), true);
-    eq(RA.isNotString(true), true);
-    eq(RA.isNotString(new Date()), true);
-    eq(RA.isNotString(new Error()), true);
-    eq(RA.isNotString(Array.prototype.slice), true);
-    eq(RA.isNotString({ 0: 1, length: 1 }), true);
-    eq(RA.isNotString(1), true);
-    eq(RA.isNotString(/x/), true);
-    eq(RA.isNotString(Symbol), true);
+    assert.isTrue(RA.isNotString(args));
+    assert.isTrue(RA.isNotString([1, 2, 3]));
+    assert.isTrue(RA.isNotString(true));
+    assert.isTrue(RA.isNotString(new Date()));
+    assert.isTrue(RA.isNotString(new Error()));
+    assert.isTrue(RA.isNotString(Array.prototype.slice));
+    assert.isTrue(RA.isNotString({ 0: 1, length: 1 }));
+    assert.isTrue(RA.isNotString(1));
+    assert.isTrue(RA.isNotString(/x/));
+    assert.isTrue(RA.isNotString(Symbol));
   });
 });

--- a/test/isNotUndefined.js
+++ b/test/isNotUndefined.js
@@ -1,14 +1,15 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isNotUndefined', function() {
   it('tests a value for complement of `undefined`', function() {
-    eq(RA.isNotUndefined(void 0), false);
-    eq(RA.isNotUndefined(undefined), false);
-    eq(RA.isNotUndefined(null), true);
-    eq(RA.isNotUndefined([]), true);
-    eq(RA.isNotUndefined({}), true);
-    eq(RA.isNotUndefined(0), true);
-    eq(RA.isNotUndefined(''), true);
+    assert.isFalse(RA.isNotUndefined(void 0));
+    assert.isFalse(RA.isNotUndefined(undefined));
+    assert.isTrue(RA.isNotUndefined(null));
+    assert.isTrue(RA.isNotUndefined([]));
+    assert.isTrue(RA.isNotUndefined({}));
+    assert.isTrue(RA.isNotUndefined(0));
+    assert.isTrue(RA.isNotUndefined(''));
   });
 });

--- a/test/isNotValidDate.js
+++ b/test/isNotValidDate.js
@@ -1,36 +1,37 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNotValidDate', function() {
   it('tests a value for complement of valid `Date`', function() {
-    eq(RA.isNotValidDate(new Date()), false);
+    assert.isFalse(RA.isNotValidDate(new Date()));
 
-    eq(RA.isNotValidDate(new Date('a')), true);
-    eq(RA.isNotValidDate(Date.now()), true);
-    eq(RA.isNotValidDate(args), true);
-    eq(RA.isNotValidDate([1, 2, 3]), true);
-    eq(RA.isNotValidDate(Object(true)), true);
-    eq(RA.isNotValidDate(new Error()), true);
-    eq(RA.isNotValidDate(RA), true);
-    eq(RA.isNotValidDate(Array.prototype.slice), true);
-    eq(RA.isNotValidDate({ a: 1 }), true);
-    eq(RA.isNotValidDate(Object(0)), true);
-    eq(RA.isNotValidDate(/x/), true);
-    eq(RA.isNotValidDate(Object('a')), true);
+    assert.isTrue(RA.isNotValidDate(new Date('a')));
+    assert.isTrue(RA.isNotValidDate(Date.now()));
+    assert.isTrue(RA.isNotValidDate(args));
+    assert.isTrue(RA.isNotValidDate([1, 2, 3]));
+    assert.isTrue(RA.isNotValidDate(Object(true)));
+    assert.isTrue(RA.isNotValidDate(new Error()));
+    assert.isTrue(RA.isNotValidDate(RA));
+    assert.isTrue(RA.isNotValidDate(Array.prototype.slice));
+    assert.isTrue(RA.isNotValidDate({ a: 1 }));
+    assert.isTrue(RA.isNotValidDate(Object(0)));
+    assert.isTrue(RA.isNotValidDate(/x/));
+    assert.isTrue(RA.isNotValidDate(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isNotValidDate(Symbol), true);
+      assert.isTrue(RA.isNotValidDate(Symbol));
     }
 
-    eq(RA.isNotValidDate(null), true);
-    eq(RA.isNotValidDate(undefined), true);
+    assert.isTrue(RA.isNotValidDate(null));
+    assert.isTrue(RA.isNotValidDate(undefined));
   });
 });
 
 describe('isInvalidDate', function() {
   it('tests an alias', function() {
-    eq(RA.isNotValidDate === RA.isInvalidDate, true);
+    assert.strictEqual(RA.isNotValidDate, RA.isInvalidDate);
   });
 });

--- a/test/isNotValidNumber.js
+++ b/test/isNotValidNumber.js
@@ -1,41 +1,42 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNotValidNumber', function() {
   it('tests a value for complement of valid `Number`', function() {
-    eq(RA.isNotValidNumber(0), false);
-    eq(RA.isNotValidNumber(0.1), false);
-    eq(RA.isNotValidNumber(-0.1), false);
-    eq(RA.isNotValidNumber(1), false);
-    eq(RA.isNotValidNumber(-1), false);
-    eq(RA.isNotValidNumber(MAX_SAFE_INTEGER), false);
-    eq(RA.isNotValidNumber(MIN_SAFE_INTEGER), false);
-    eq(RA.isNotValidNumber(Number.MAX_VALUE), false);
-    eq(RA.isNotValidNumber(Number.MIN_VALUE), false);
+    assert.isFalse(RA.isNotValidNumber(0));
+    assert.isFalse(RA.isNotValidNumber(0.1));
+    assert.isFalse(RA.isNotValidNumber(-0.1));
+    assert.isFalse(RA.isNotValidNumber(1));
+    assert.isFalse(RA.isNotValidNumber(-1));
+    assert.isFalse(RA.isNotValidNumber(MAX_SAFE_INTEGER));
+    assert.isFalse(RA.isNotValidNumber(MIN_SAFE_INTEGER));
+    assert.isFalse(RA.isNotValidNumber(Number.MAX_VALUE));
+    assert.isFalse(RA.isNotValidNumber(Number.MIN_VALUE));
 
-    eq(RA.isNotValidNumber(NaN), true);
-    eq(RA.isNotValidNumber(Infinity), true);
-    eq(RA.isNotValidNumber(-Infinity), true);
-    eq(RA.isNotValidNumber(new Date()), true);
-    eq(RA.isNotValidNumber(args), true);
-    eq(RA.isNotValidNumber([1, 2, 3]), true);
-    eq(RA.isNotValidNumber(Object(true)), true);
-    eq(RA.isNotValidNumber(new Error()), true);
-    eq(RA.isNotValidNumber(RA), true);
-    eq(RA.isNotValidNumber(Array.prototype.slice), true);
-    eq(RA.isNotValidNumber({ a: 1 }), true);
-    eq(RA.isNotValidNumber(/x/), true);
-    eq(RA.isNotValidNumber(Object('a')), true);
+    assert.isTrue(RA.isNotValidNumber(NaN));
+    assert.isTrue(RA.isNotValidNumber(Infinity));
+    assert.isTrue(RA.isNotValidNumber(-Infinity));
+    assert.isTrue(RA.isNotValidNumber(new Date()));
+    assert.isTrue(RA.isNotValidNumber(args));
+    assert.isTrue(RA.isNotValidNumber([1, 2, 3]));
+    assert.isTrue(RA.isNotValidNumber(Object(true)));
+    assert.isTrue(RA.isNotValidNumber(new Error()));
+    assert.isTrue(RA.isNotValidNumber(RA));
+    assert.isTrue(RA.isNotValidNumber(Array.prototype.slice));
+    assert.isTrue(RA.isNotValidNumber({ a: 1 }));
+    assert.isTrue(RA.isNotValidNumber(/x/));
+    assert.isTrue(RA.isNotValidNumber(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isNotValidNumber(Symbol), true);
+      assert.isTrue(RA.isNotValidNumber(Symbol));
     }
 
-    eq(RA.isNotValidNumber(null), true);
-    eq(RA.isNotValidNumber(undefined), true);
+    assert.isTrue(RA.isNotValidNumber(null));
+    assert.isTrue(RA.isNotValidNumber(undefined));
   });
 });

--- a/test/isNull.js
+++ b/test/isNull.js
@@ -1,13 +1,14 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isNull', function() {
   it('tests a value for `null`', function() {
-    eq(RA.isNull(void 0), false);
-    eq(RA.isNull(null), true);
-    eq(RA.isNull([]), false);
-    eq(RA.isNull({}), false);
-    eq(RA.isNull(0), false);
-    eq(RA.isNull(''), false);
+    assert.isFalse(RA.isNull(void 0));
+    assert.isTrue(RA.isNull(null));
+    assert.isFalse(RA.isNull([]));
+    assert.isFalse(RA.isNull({}));
+    assert.isFalse(RA.isNull(0));
+    assert.isFalse(RA.isNull(''));
   });
 });


### PR DESCRIPTION

Batch 8

test/

- isNotPlainObj.js
- isNotRegExp.js
- isNotString.js
- isNotUndefined.js
- isNotValidDate.js
- isNotValidNumber.js
- isNull.js
