### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#9

### DIFF
--- a/test/isNumber.js
+++ b/test/isNumber.js
@@ -1,40 +1,41 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isNumber', function() {
   it('tests a value for `Number`', function() {
-    eq(RA.isNumber(0), true);
-    eq(RA.isNumber(0.1), true);
-    eq(RA.isNumber(Object(0)), true);
-    eq(RA.isNumber(Object(0.1)), true);
-    eq(RA.isNumber(NaN), true);
-    eq(RA.isNumber(Infinity), true);
-    eq(RA.isNumber(-Infinity), true);
-    eq(RA.isNumber(MAX_SAFE_INTEGER), true);
-    eq(RA.isNumber(MIN_SAFE_INTEGER), true);
-    eq(RA.isNumber(Number.MAX_VALUE), true);
-    eq(RA.isNumber(Number.MIN_VALUE), true);
+    assert.isTrue(RA.isNumber(0));
+    assert.isTrue(RA.isNumber(0.1));
+    assert.isTrue(RA.isNumber(Object(0)));
+    assert.isTrue(RA.isNumber(Object(0.1)));
+    assert.isTrue(RA.isNumber(NaN));
+    assert.isTrue(RA.isNumber(Infinity));
+    assert.isTrue(RA.isNumber(-Infinity));
+    assert.isTrue(RA.isNumber(MAX_SAFE_INTEGER));
+    assert.isTrue(RA.isNumber(MIN_SAFE_INTEGER));
+    assert.isTrue(RA.isNumber(Number.MAX_VALUE));
+    assert.isTrue(RA.isNumber(Number.MIN_VALUE));
 
-    eq(RA.isNumber(new Date()), false);
-    eq(RA.isNumber(args), false);
-    eq(RA.isNumber([1, 2, 3]), false);
-    eq(RA.isNumber(Object(false)), false);
-    eq(RA.isNumber(new Error()), false);
-    eq(RA.isNumber(RA), false);
-    eq(RA.isNumber(Array.prototype.slice), false);
-    eq(RA.isNumber({ a: 1 }), false);
-    eq(RA.isNumber(/x/), false);
-    eq(RA.isNumber(Object('a')), false);
+    assert.isFalse(RA.isNumber(new Date()));
+    assert.isFalse(RA.isNumber(args));
+    assert.isFalse(RA.isNumber([1, 2, 3]));
+    assert.isFalse(RA.isNumber(Object(false)));
+    assert.isFalse(RA.isNumber(new Error()));
+    assert.isFalse(RA.isNumber(RA));
+    assert.isFalse(RA.isNumber(Array.prototype.slice));
+    assert.isFalse(RA.isNumber({ a: 1 }));
+    assert.isFalse(RA.isNumber(/x/));
+    assert.isFalse(RA.isNumber(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isNumber(Symbol), false);
+      assert.isFalse(RA.isNumber(Symbol));
     }
 
-    eq(RA.isNumber(null), false);
-    eq(RA.isNumber(undefined), false);
+    assert.isFalse(RA.isNumber(null));
+    assert.isFalse(RA.isNumber(undefined));
   });
 });

--- a/test/isObj.js
+++ b/test/isObj.js
@@ -1,33 +1,37 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isObj', function() {
   it('tests a value for language type of `Object`', function() {
-    eq(RA.isObj({}), true);
-    eq(RA.isObj(Object(true)), true);
-    eq(RA.isObj(Object.create(null)), true);
-    eq(RA.isObj(args), true);
-    eq(RA.isObj([1, 2, 3]), true);
-    eq(RA.isObj(Object(false)), true);
-    eq(RA.isObj(new Date()), true);
-    eq(RA.isObj(new Error()), true);
-    eq(RA.isObj(RA), true);
-    eq(RA.isObj(Array.prototype.slice), true);
-    eq(RA.isObj({ a: 1 }), true);
-    eq(RA.isObj(Object(0)), true);
-    eq(RA.isObj(/x/), true);
-    eq(RA.isObj(Object('a')), true);
-    eq(RA.isObj(Symbol), typeof Symbol !== 'undefined');
+    assert.isTrue(RA.isObj({}));
+    assert.isTrue(RA.isObj(Object(true)));
+    assert.isTrue(RA.isObj(Object.create(null)));
+    assert.isTrue(RA.isObj(args));
+    assert.isTrue(RA.isObj([1, 2, 3]));
+    assert.isTrue(RA.isObj(Object(false)));
+    assert.isTrue(RA.isObj(new Date()));
+    assert.isTrue(RA.isObj(new Error()));
+    assert.isTrue(RA.isObj(RA));
+    assert.isTrue(RA.isObj(Array.prototype.slice));
+    assert.isTrue(RA.isObj({ a: 1 }));
+    assert.isTrue(RA.isObj(Object(0)));
+    assert.isTrue(RA.isObj(/x/));
+    assert.isTrue(RA.isObj(Object('a')));
 
-    eq(RA.isObj(null), false);
-    eq(RA.isObj(undefined), false);
+    if (Symbol !== 'undefined') {
+      assert.isTrue(RA.isObj(Symbol));
+    }
+
+    assert.isFalse(RA.isObj(null));
+    assert.isFalse(RA.isObj(undefined));
   });
 });
 
 describe('isObject', function() {
   it('tests an alias', function() {
-    eq(RA.isObj === RA.isObject, true);
+    assert.strictEqual(RA.isObj, RA.isObject);
   });
 });

--- a/test/isObjLike.js
+++ b/test/isObjLike.js
@@ -1,32 +1,36 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isObjLike', function() {
   it('tests a value for object-like interface', function() {
-    eq(RA.isObjLike({}), true);
-    eq(RA.isObjLike(Object(true)), true);
-    eq(RA.isObjLike(args), true);
-    eq(RA.isObjLike([1, 2, 3]), true);
-    eq(RA.isObjLike(Object(false)), true);
-    eq(RA.isObjLike(new Date()), true);
-    eq(RA.isObjLike(new Error()), true);
-    eq(RA.isObjLike(RA), true);
-    eq(RA.isObjLike({ a: 1 }), true);
-    eq(RA.isObjLike(Object(0)), true);
-    eq(RA.isObjLike(/x/), true);
-    eq(RA.isObjLike(Object('a')), true);
+    assert.isTrue(RA.isObjLike({}));
+    assert.isTrue(RA.isObjLike(Object(true)));
+    assert.isTrue(RA.isObjLike(args));
+    assert.isTrue(RA.isObjLike([1, 2, 3]));
+    assert.isTrue(RA.isObjLike(Object(false)));
+    assert.isTrue(RA.isObjLike(new Date()));
+    assert.isTrue(RA.isObjLike(new Error()));
+    assert.isTrue(RA.isObjLike(RA));
+    assert.isTrue(RA.isObjLike({ a: 1 }));
+    assert.isTrue(RA.isObjLike(Object(0)));
+    assert.isTrue(RA.isObjLike(/x/));
+    assert.isTrue(RA.isObjLike(Object('a')));
 
-    eq(RA.isObjLike(Symbol), false);
-    eq(RA.isObjLike(Array.prototype.slice), false);
-    eq(RA.isObjLike(null), false);
-    eq(RA.isObjLike(undefined), false);
+    if (Symbol !== 'undefined') {
+      assert.isFalse(RA.isObjLike(Symbol));
+    }
+
+    assert.isFalse(RA.isObjLike(Array.prototype.slice));
+    assert.isFalse(RA.isObjLike(null));
+    assert.isFalse(RA.isObjLike(undefined));
   });
 });
 
 describe('isObjectLike', function() {
   it('tests an alias', function() {
-    eq(RA.isObjLike === RA.isObjectLike, true);
+    assert.strictEqual(RA.isObjLike, RA.isObjectLike);
   });
 });

--- a/test/isOdd.js
+++ b/test/isOdd.js
@@ -1,43 +1,44 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isOdd', function() {
   it('tests a value for odd integer `Number`', function() {
-    eq(RA.isOdd(0), false);
-    eq(RA.isOdd(4), false);
-    eq(RA.isOdd(Object(0)), false);
-    eq(RA.isOdd(Object(0.1)), false);
-    eq(RA.isOdd(NaN), false);
-    eq(RA.isOdd(3), true);
-    eq(RA.isOdd(7), true);
-    eq(RA.isOdd(-3), true);
-    eq(RA.isOdd(-7), true);
-    eq(RA.isOdd(-Infinity), false);
-    eq(RA.isOdd(MAX_SAFE_INTEGER), true);
-    eq(RA.isOdd(MIN_SAFE_INTEGER), true);
-    eq(RA.isOdd(Number.MAX_VALUE), false);
-    eq(RA.isOdd(Number.MIN_VALUE), false);
+    assert.isFalse(RA.isOdd(0));
+    assert.isFalse(RA.isOdd(4));
+    assert.isFalse(RA.isOdd(Object(0)));
+    assert.isFalse(RA.isOdd(Object(0.1)));
+    assert.isFalse(RA.isOdd(NaN));
+    assert.isTrue(RA.isOdd(3));
+    assert.isTrue(RA.isOdd(7));
+    assert.isTrue(RA.isOdd(-3));
+    assert.isTrue(RA.isOdd(-7));
+    assert.isFalse(RA.isOdd(-Infinity));
+    assert.isTrue(RA.isOdd(MAX_SAFE_INTEGER));
+    assert.isTrue(RA.isOdd(MIN_SAFE_INTEGER));
+    assert.isFalse(RA.isOdd(Number.MAX_VALUE));
+    assert.isFalse(RA.isOdd(Number.MIN_VALUE));
 
-    eq(RA.isOdd(new Date()), false);
-    eq(RA.isOdd(args), false);
-    eq(RA.isOdd([1, 2, 3]), false);
-    eq(RA.isOdd(Object(false)), false);
-    eq(RA.isOdd(new Error()), false);
-    eq(RA.isOdd(RA), false);
-    eq(RA.isOdd(Array.prototype.slice), false);
-    eq(RA.isOdd({ a: 1 }), false);
-    eq(RA.isOdd(/x/), false);
-    eq(RA.isOdd(Object('a')), false);
+    assert.isFalse(RA.isOdd(new Date()));
+    assert.isFalse(RA.isOdd(args));
+    assert.isFalse(RA.isOdd([1, 2, 3]));
+    assert.isFalse(RA.isOdd(Object(false)));
+    assert.isFalse(RA.isOdd(new Error()));
+    assert.isFalse(RA.isOdd(RA));
+    assert.isFalse(RA.isOdd(Array.prototype.slice));
+    assert.isFalse(RA.isOdd({ a: 1 }));
+    assert.isFalse(RA.isOdd(/x/));
+    assert.isFalse(RA.isOdd(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isOdd(Symbol), false);
+      assert.isFalse(RA.isOdd(Symbol));
     }
 
-    eq(RA.isOdd(null), false);
-    eq(RA.isOdd(undefined), false);
+    assert.isFalse(RA.isOdd(null));
+    assert.isFalse(RA.isOdd(undefined));
   });
 });

--- a/test/isPair.js
+++ b/test/isPair.js
@@ -1,19 +1,20 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isPair', function() {
   it('tests a value for pair', function() {
-    eq(RA.isPair([]), false);
-    eq(RA.isPair([0]), false);
-    eq(RA.isPair([0, 1]), true);
-    eq(RA.isPair([0, 1, 2]), false);
-    eq(RA.isPair(0), false);
-    eq(RA.isPair(''), false);
-    eq(RA.isPair('foo'), false);
-    eq(RA.isPair(false), false);
-    eq(RA.isPair(true), false);
-    eq(RA.isPair(new Date()), false);
-    eq(RA.isPair({ 0: 0, 1: 1 }), false);
-    eq(RA.isPair({ foo: 0, bar: 1 }), false);
+    assert.isFalse(RA.isPair([]));
+    assert.isFalse(RA.isPair([0]));
+    assert.isTrue(RA.isPair([0, 1]));
+    assert.isFalse(RA.isPair([0, 1, 2]));
+    assert.isFalse(RA.isPair(0));
+    assert.isFalse(RA.isPair(''));
+    assert.isFalse(RA.isPair('foo'));
+    assert.isFalse(RA.isPair(false));
+    assert.isFalse(RA.isPair(true));
+    assert.isFalse(RA.isPair(new Date()));
+    assert.isFalse(RA.isPair({ 0: 0, 1: 1 }));
+    assert.isFalse(RA.isPair({ foo: 0, bar: 1 }));
   });
 });

--- a/test/isPlainObj.js
+++ b/test/isPlainObj.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import element from './shared/element';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
@@ -12,53 +13,53 @@ class Bar {
 
 describe('isPlainObj', function() {
   it('tests a value for POJO', function() {
-    eq(RA.isPlainObj({}), true);
-    eq(RA.isPlainObj({ prop: 'value' }), true);
-    eq(RA.isPlainObj({ constructor: Bar }), true);
-    eq(RA.isPlainObj(new Bar()), false);
-    eq(RA.isPlainObj(['a', 'b', 'c']), false);
+    assert.isTrue(RA.isPlainObj({}));
+    assert.isTrue(RA.isPlainObj({ prop: 'value' }));
+    assert.isTrue(RA.isPlainObj({ constructor: Bar }));
+    assert.isFalse(RA.isPlainObj(new Bar()));
+    assert.isFalse(RA.isPlainObj(['a', 'b', 'c']));
   });
 
   it('tests a value with prototype of null', function() {
-    eq(RA.isPlainObj(Object.create(null)), true);
+    assert.isTrue(RA.isPlainObj(Object.create(null)));
 
     const object = Object.create(null);
     object.constructor = Object.prototype.constructor;
 
-    eq(RA.isPlainObj(object), true);
+    assert.isTrue(RA.isPlainObj(object));
   });
 
   it('tests a value with `valueOf` property', function() {
-    eq(RA.isPlainObj({ valueOf: 1 }), true);
+    assert.isTrue(RA.isPlainObj({ valueOf: 1 }));
   });
 
   it('test a value with custom prototype', function() {
-    eq(RA.isPlainObj(Object.create({ a: 3 })), true);
+    assert.isTrue(RA.isPlainObj(Object.create({ a: 3 })));
   });
 
   it('test a value that is DOM element', function() {
     if (element) {
-      eq(RA.isPlainObj(element), false);
+      assert.isFalse(RA.isPlainObj(element));
     }
   });
 
   it('test a value for non-objects', function() {
-    eq(RA.isPlainObj(args), false);
-    eq(RA.isPlainObj(Error), false);
-    eq(RA.isPlainObj(Math), false);
-    eq(RA.isPlainObj(true), false);
-    eq(RA.isPlainObj('abc'), false);
+    assert.isFalse(RA.isPlainObj(args));
+    assert.isFalse(RA.isPlainObj(Error));
+    assert.isFalse(RA.isPlainObj(Math));
+    assert.isFalse(RA.isPlainObj(true));
+    assert.isFalse(RA.isPlainObj('abc'));
   });
 
   it('test a value for Symbol', function() {
-    if (Symbol) {
-      eq(RA.isPlainObj(Symbol.for('symbol')), false);
+    if (Symbol !== 'undefined') {
+      assert.isFalse(RA.isPlainObj(Symbol.for('symbol')));
     }
   });
 });
 
 describe('isPlainObject', function() {
   it('tests an alias', function() {
-    eq(RA.isPlainObj === RA.isPlainObject, true);
+    assert.strictEqual(RA.isPlainObj, RA.isPlainObject);
   });
 });

--- a/test/isPositive.js
+++ b/test/isPositive.js
@@ -1,40 +1,41 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
 import MAX_SAFE_INTEGER from '../src/internal/polyfills/Number.MAX_SAFE_INTEGER';
 import MIN_SAFE_INTEGER from '../src/internal/polyfills/Number.MIN_SAFE_INTEGER';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isPositive', function() {
   it('tests a value for positive `Number`', function() {
-    eq(RA.isPositive(0), false);
-    eq(RA.isPositive(0.1), true);
-    eq(RA.isPositive(Object(0)), false);
-    eq(RA.isPositive(Object(0.1)), true);
-    eq(RA.isPositive(NaN), false);
-    eq(RA.isPositive(Infinity), true);
-    eq(RA.isPositive(-Infinity), false);
-    eq(RA.isPositive(MAX_SAFE_INTEGER), true);
-    eq(RA.isPositive(MIN_SAFE_INTEGER), false);
-    eq(RA.isPositive(Number.MAX_VALUE), true);
-    eq(RA.isPositive(Number.MIN_VALUE), true);
+    assert.isFalse(RA.isPositive(0));
+    assert.isTrue(RA.isPositive(0.1));
+    assert.isFalse(RA.isPositive(Object(0)));
+    assert.isTrue(RA.isPositive(Object(0.1)));
+    assert.isFalse(RA.isPositive(NaN));
+    assert.isTrue(RA.isPositive(Infinity));
+    assert.isFalse(RA.isPositive(-Infinity));
+    assert.isTrue(RA.isPositive(MAX_SAFE_INTEGER));
+    assert.isFalse(RA.isPositive(MIN_SAFE_INTEGER));
+    assert.isTrue(RA.isPositive(Number.MAX_VALUE));
+    assert.isTrue(RA.isPositive(Number.MIN_VALUE));
 
-    eq(RA.isPositive(new Date()), false);
-    eq(RA.isPositive(args), false);
-    eq(RA.isPositive([1, 2, 3]), false);
-    eq(RA.isPositive(Object(false)), false);
-    eq(RA.isPositive(new Error()), false);
-    eq(RA.isPositive(RA), false);
-    eq(RA.isPositive(Array.prototype.slice), false);
-    eq(RA.isPositive({ a: 1 }), false);
-    eq(RA.isPositive(/x/), false);
-    eq(RA.isPositive(Object('a')), false);
+    assert.isFalse(RA.isPositive(new Date()));
+    assert.isFalse(RA.isPositive(args));
+    assert.isFalse(RA.isPositive([1, 2, 3]));
+    assert.isFalse(RA.isPositive(Object(false)));
+    assert.isFalse(RA.isPositive(new Error()));
+    assert.isFalse(RA.isPositive(RA));
+    assert.isFalse(RA.isPositive(Array.prototype.slice));
+    assert.isFalse(RA.isPositive({ a: 1 }));
+    assert.isFalse(RA.isPositive(/x/));
+    assert.isFalse(RA.isPositive(Object('a')));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isPositive(Symbol), false);
+      assert.isFalse(RA.isPositive(Symbol));
     }
 
-    eq(RA.isPositive(null), false);
-    eq(RA.isPositive(undefined), false);
+    assert.isFalse(RA.isPositive(null));
+    assert.isFalse(RA.isPositive(undefined));
   });
 });


### PR DESCRIPTION
Batch 9

test/

- isNumber.js
- isObj.js
- isObjLike.js
- isOdd.js
- isPair.js
- isPlainObj.js
- isPositive.js