### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#10

### DIFF
--- a/test/isPromise.js
+++ b/test/isPromise.js
@@ -1,29 +1,32 @@
+import { assert } from 'chai';
 import { contains } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isPromise', function() {
   context('given value is not a Promise', function() {
     specify('should return false', function() {
-      eq(RA.isPromise(args), false);
-      eq(RA.isPromise([1, 2, 3]), false);
-      eq(RA.isPromise(true), false);
-      eq(RA.isPromise(new Date()), false);
-      eq(RA.isPromise(new Error()), false);
-      eq(RA.isPromise(Array.prototype.slice), false);
-      eq(RA.isPromise({ 0: 1, length: 1 }), false);
-      eq(RA.isPromise(1), false);
-      eq(RA.isPromise(/x/), false);
-      eq(RA.isPromise(Symbol), false);
+      assert.isFalse(RA.isPromise(args));
+      assert.isFalse(RA.isPromise([1, 2, 3]));
+      assert.isFalse(RA.isPromise(true));
+      assert.isFalse(RA.isPromise(new Date()));
+      assert.isFalse(RA.isPromise(new Error()));
+      assert.isFalse(RA.isPromise(Array.prototype.slice));
+      assert.isFalse(RA.isPromise({ 0: 1, length: 1 }));
+      assert.isFalse(RA.isPromise(1));
+      assert.isFalse(RA.isPromise(/x/));
+
+      if (Symbol !== 'undefined') {
+        assert.isFalse(RA.isPromise(Symbol));
+      }
     });
   });
 
   context('given value is thenable object', function() {
     specify('should return false', function() {
-      eq(RA.isPromise({ then: () => {} }), false);
+      assert.isFalse(RA.isPromise({ then: () => {} }));
     });
   });
 
@@ -31,7 +34,7 @@ describe('isPromise', function() {
     specify('should return false', function() {
       const objWithPrototype = Object.create({ then: () => {} });
 
-      eq(RA.isPromise(objWithPrototype), false);
+      assert.isFalse(RA.isPromise(objWithPrototype));
     });
   });
 
@@ -44,8 +47,8 @@ describe('isPromise', function() {
       const resolvedP = Promise.resolve();
       const rejectedP = Promise.reject();
 
-      eq(RA.isPromise(resolvedP), hasNativePromise);
-      eq(RA.isPromise(rejectedP), hasNativePromise);
+      assert.strictEqual(RA.isPromise(resolvedP), hasNativePromise);
+      assert.strictEqual(RA.isPromise(rejectedP), hasNativePromise);
 
       rejectedP.catch(RA.noop);
     });
@@ -56,7 +59,7 @@ describe('isPromise', function() {
       const func = () => {};
       func.then = () => {};
 
-      eq(RA.isPromise(func), false);
+      assert.isFalse(RA.isPromise(func));
     });
   });
 });

--- a/test/isRegExp.js
+++ b/test/isRegExp.js
@@ -1,36 +1,34 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import args from './shared/arguments';
 import Symbol from './shared/Symbol';
 
 describe('isRegExp', function() {
   it('tests a value for `RegExp`', function() {
-    eq(RA.isRegExp(new RegExp()), true);
-    eq(RA.isRegExp(/(?:)/), true);
+    assert.isTrue(RA.isRegExp(new RegExp()));
+    assert.isTrue(RA.isRegExp(/(?:)/));
 
-    eq(RA.isRegExp('a'), false);
-    eq(RA.isRegExp(1), false);
-    eq(RA.isRegExp([]), false);
-    eq(RA.isRegExp({}), false);
-    eq(RA.isRegExp(true), false);
-    eq(RA.isRegExp(false), false);
-    eq(RA.isRegExp(new Error()), false);
-    eq(RA.isRegExp(new Date()), false);
-    eq(
-      RA.isRegExp(function() {}),
-      false
-    );
-    eq(RA.isRegExp(Object(0)), false);
-    eq(RA.isRegExp(Object('a')), false);
-    eq(RA.isRegExp(Object(false)), false);
-    eq(RA.isRegExp(RA), false);
-    eq(RA.isRegExp(args), false);
+    assert.isFalse(RA.isRegExp('a'));
+    assert.isFalse(RA.isRegExp(1));
+    assert.isFalse(RA.isRegExp([]));
+    assert.isFalse(RA.isRegExp({}));
+    assert.isFalse(RA.isRegExp(true));
+    assert.isFalse(RA.isRegExp(false));
+    assert.isFalse(RA.isRegExp(new Error()));
+    assert.isFalse(RA.isRegExp(new Date()));
+    assert.isFalse(RA.isRegExp(function() {}));
+    assert.isFalse(RA.isRegExp(Object(0)));
+    assert.isFalse(RA.isRegExp(Object('a')));
+    assert.isFalse(RA.isRegExp(Object(false)));
+    assert.isFalse(RA.isRegExp(RA));
+    assert.isFalse(RA.isRegExp(args));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isRegExp(Symbol), false);
+      assert.isFalse(RA.isRegExp(Symbol));
     }
 
-    eq(RA.isRegExp(null), false);
-    eq(RA.isRegExp(undefined), false);
+    assert.isFalse(RA.isRegExp(null));
+    assert.isFalse(RA.isRegExp(undefined));
   });
 });

--- a/test/isString.js
+++ b/test/isString.js
@@ -1,22 +1,26 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isString', function() {
   it('tests a value for `String`', function() {
-    eq(RA.isString('abc'), true);
-    eq(RA.isString(Object('abc')), true);
+    assert.isTrue(RA.isString('abc'));
+    assert.isTrue(RA.isString(Object('abc')));
 
-    eq(RA.isString(args), false);
-    eq(RA.isString([1, 2, 3]), false);
-    eq(RA.isString(true), false);
-    eq(RA.isString(new Date()), false);
-    eq(RA.isString(new Error()), false);
-    eq(RA.isString(Array.prototype.slice), false);
-    eq(RA.isString({ 0: 1, length: 1 }), false);
-    eq(RA.isString(1), false);
-    eq(RA.isString(/x/), false);
-    eq(RA.isString(Symbol), false);
+    assert.isFalse(RA.isString(args));
+    assert.isFalse(RA.isString([1, 2, 3]));
+    assert.isFalse(RA.isString(true));
+    assert.isFalse(RA.isString(new Date()));
+    assert.isFalse(RA.isString(new Error()));
+    assert.isFalse(RA.isString(Array.prototype.slice));
+    assert.isFalse(RA.isString({ 0: 1, length: 1 }));
+    assert.isFalse(RA.isString(1));
+    assert.isFalse(RA.isString(/x/));
+
+    if (Symbol !== 'undefined') {
+      assert.isFalse(RA.isString(Symbol));
+    }
   });
 });

--- a/test/isThenable.js
+++ b/test/isThenable.js
@@ -1,27 +1,31 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isThenable', function() {
   context('given value is not `thenable`', function() {
     specify('should return false', function() {
-      eq(RA.isThenable(args), false);
-      eq(RA.isThenable([1, 2, 3]), false);
-      eq(RA.isThenable(true), false);
-      eq(RA.isThenable(new Date()), false);
-      eq(RA.isThenable(new Error()), false);
-      eq(RA.isThenable(Array.prototype.slice), false);
-      eq(RA.isThenable({ 0: 1, length: 1 }), false);
-      eq(RA.isThenable(1), false);
-      eq(RA.isThenable(/x/), false);
-      eq(RA.isThenable(Symbol), false);
+      assert.isFalse(RA.isThenable(args));
+      assert.isFalse(RA.isThenable([1, 2, 3]));
+      assert.isFalse(RA.isThenable(true));
+      assert.isFalse(RA.isThenable(new Date()));
+      assert.isFalse(RA.isThenable(new Error()));
+      assert.isFalse(RA.isThenable(Array.prototype.slice));
+      assert.isFalse(RA.isThenable({ 0: 1, length: 1 }));
+      assert.isFalse(RA.isThenable(1));
+      assert.isFalse(RA.isThenable(/x/));
+
+      if (Symbol !== 'undefined') {
+        assert.isFalse(RA.isThenable(Symbol));
+      }
     });
   });
 
   context('given value is thenable object', function() {
     specify('should return true', function() {
-      eq(RA.isThenable({ then: () => {} }), true);
+      assert.isTrue(RA.isThenable({ then: () => {} }));
     });
   });
 
@@ -29,7 +33,7 @@ describe('isThenable', function() {
     specify('should return true', function() {
       const objWithPrototype = Object.create({ then: () => {} });
 
-      eq(RA.isThenable(objWithPrototype), true);
+      assert.isTrue(RA.isThenable(objWithPrototype));
     });
   });
 
@@ -38,8 +42,8 @@ describe('isThenable', function() {
       const resolvedP = Promise.resolve();
       const rejectedP = Promise.reject();
 
-      eq(RA.isThenable(resolvedP), true);
-      eq(RA.isThenable(rejectedP), true);
+      assert.isTrue(RA.isThenable(resolvedP));
+      assert.isTrue(RA.isThenable(rejectedP));
 
       rejectedP.catch(RA.noop);
     });
@@ -50,7 +54,7 @@ describe('isThenable', function() {
       const func = () => {};
       func.then = () => {};
 
-      eq(RA.isThenable(func), true);
+      assert.isTrue(RA.isThenable(func));
     });
   });
 });

--- a/test/isTrue.js
+++ b/test/isTrue.js
@@ -1,40 +1,41 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isTrue', function() {
   it("tests whether a value is 'true' primative", function() {
-    eq(RA.isTrue(true), true);
-    eq(RA.isTrue(Boolean(true)), true);
+    assert.isTrue(RA.isTrue(true));
+    assert.isTrue(RA.isTrue(Boolean(true)));
 
-    eq(RA.isTrue(false), false);
-    eq(RA.isTrue(Boolean(false)), false);
-    eq(RA.isTrue(new Boolean(true)), false);
-    eq(RA.isTrue(new Boolean(false)), false);
-    eq(RA.isTrue('true'), false);
-    eq(RA.isTrue('abc'), false);
-    eq(RA.isTrue(Object('abc')), false);
-    eq(RA.isTrue(args), false);
-    eq(RA.isTrue([1, 2, 3]), false);
-    eq(RA.isTrue(new Date()), false);
-    eq(RA.isTrue(new Error()), false);
-    eq(RA.isTrue(Array.prototype.slice), false);
-    eq(RA.isTrue({ 0: 1, length: 1 }), false);
-    eq(RA.isTrue(/x/), false);
-    eq(RA.isTrue({}), false);
-    eq(RA.isTrue([]), false);
-    eq(RA.isTrue(Infinity), false);
-    eq(RA.isTrue(-0), false);
-    eq(RA.isTrue(0), false);
-    eq(RA.isTrue(1), false);
-    eq(RA.isTrue(''), false);
-    eq(RA.isTrue(null), false);
-    eq(RA.isTrue(undefined), false);
-    eq(RA.isTrue(NaN), false);
+    assert.isFalse(RA.isTrue(false));
+    assert.isFalse(RA.isTrue(Boolean(false)));
+    assert.isFalse(RA.isTrue(new Boolean(true)));
+    assert.isFalse(RA.isTrue(new Boolean(false)));
+    assert.isFalse(RA.isTrue('true'));
+    assert.isFalse(RA.isTrue('abc'));
+    assert.isFalse(RA.isTrue(Object('abc')));
+    assert.isFalse(RA.isTrue(args));
+    assert.isFalse(RA.isTrue([1, 2, 3]));
+    assert.isFalse(RA.isTrue(new Date()));
+    assert.isFalse(RA.isTrue(new Error()));
+    assert.isFalse(RA.isTrue(Array.prototype.slice));
+    assert.isFalse(RA.isTrue({ 0: 1, length: 1 }));
+    assert.isFalse(RA.isTrue(/x/));
+    assert.isFalse(RA.isTrue({}));
+    assert.isFalse(RA.isTrue([]));
+    assert.isFalse(RA.isTrue(Infinity));
+    assert.isFalse(RA.isTrue(-0));
+    assert.isFalse(RA.isTrue(0));
+    assert.isFalse(RA.isTrue(1));
+    assert.isFalse(RA.isTrue(''));
+    assert.isFalse(RA.isTrue(null));
+    assert.isFalse(RA.isTrue(undefined));
+    assert.isFalse(RA.isTrue(NaN));
 
     if (Symbol !== 'undefined') {
-      eq(RA.isTrue(Symbol), false);
+      assert.isFalse(RA.isTrue(Symbol));
     }
   });
 });

--- a/test/isTruthy.js
+++ b/test/isTruthy.js
@@ -1,32 +1,37 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import args from './shared/arguments';
 
 describe('isTruthy', function() {
   it('tests a value for `truthy`', function() {
-    eq(RA.isTruthy('abc'), true);
-    eq(RA.isTruthy(Object('abc')), true);
-    eq(RA.isTruthy(args), true);
-    eq(RA.isTruthy([1, 2, 3]), true);
-    eq(RA.isTruthy(true), true);
-    eq(RA.isTruthy(new Date()), true);
-    eq(RA.isTruthy(new Error()), true);
-    eq(RA.isTruthy(Array.prototype.slice), true);
-    eq(RA.isTruthy({ 0: 1, length: 1 }), true);
-    eq(RA.isTruthy(1), true);
-    eq(RA.isTruthy(/x/), true);
-    eq(RA.isTruthy(Symbol), RA.isNotUndefined(Symbol));
-    eq(RA.isTruthy({}), true);
-    eq(RA.isTruthy([]), true);
-    eq(RA.isTruthy(Infinity), true);
+    assert.isTrue(RA.isTruthy('abc'));
+    assert.isTrue(RA.isTruthy(Object('abc')));
+    assert.isTrue(RA.isTruthy(args));
+    assert.isTrue(RA.isTruthy([1, 2, 3]));
+    assert.isTrue(RA.isTruthy(true));
+    assert.isTrue(RA.isTruthy(new Date()));
+    assert.isTrue(RA.isTruthy(new Error()));
+    assert.isTrue(RA.isTruthy(Array.prototype.slice));
+    assert.isTrue(RA.isTruthy({ 0: 1, length: 1 }));
+    assert.isTrue(RA.isTruthy(1));
+    assert.isTrue(RA.isTruthy(/x/));
 
-    eq(RA.isTruthy(false), false);
-    eq(RA.isTruthy(0), false);
-    eq(RA.isTruthy(-0), false);
-    eq(RA.isTruthy(''), false);
-    eq(RA.isTruthy(null), false);
-    eq(RA.isTruthy(undefined), false);
-    eq(RA.isTruthy(NaN), false);
+    if (Symbol !== 'undefined') {
+      assert.isTrue(RA.isTruthy(Symbol));
+    }
+
+    assert.isTrue(RA.isTruthy({}));
+    assert.isTrue(RA.isTruthy([]));
+    assert.isTrue(RA.isTruthy(Infinity));
+
+    assert.isFalse(RA.isTruthy(false));
+    assert.isFalse(RA.isTruthy(0));
+    assert.isFalse(RA.isTruthy(-0));
+    assert.isFalse(RA.isTruthy(''));
+    assert.isFalse(RA.isTruthy(null));
+    assert.isFalse(RA.isTruthy(undefined));
+    assert.isFalse(RA.isTruthy(NaN));
   });
 });

--- a/test/isUndefined.js
+++ b/test/isUndefined.js
@@ -1,14 +1,15 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('isUndefined', function() {
   it('tests a value for `undefined`', function() {
-    eq(RA.isUndefined(void 0), true);
-    eq(RA.isUndefined(undefined), true);
-    eq(RA.isUndefined(null), false);
-    eq(RA.isUndefined([]), false);
-    eq(RA.isUndefined({}), false);
-    eq(RA.isUndefined(0), false);
-    eq(RA.isUndefined(''), false);
+    assert.isTrue(RA.isUndefined(void 0));
+    assert.isTrue(RA.isUndefined(undefined));
+    assert.isFalse(RA.isUndefined(null));
+    assert.isFalse(RA.isUndefined([]));
+    assert.isFalse(RA.isUndefined({}));
+    assert.isFalse(RA.isUndefined(0));
+    assert.isFalse(RA.isUndefined(''));
   });
 });


### PR DESCRIPTION
Batch 10
test/

- isPromise.js
- isRegExp.js
- isString.js
- isThenable.js
- isTrue.js
- isTruthy.js
- isUndefined.js
