### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#12

### DIFF
--- a/test/lengthNotEq.js
+++ b/test/lengthNotEq.js
@@ -1,15 +1,16 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('lengthNotEq', function() {
   context(
     'given the length of a list is not equal to the supplied length',
     function() {
       specify('should return true', function() {
-        eq(RA.lengthNotEq(3, [1, 2, 3, 4]), true);
-        eq(RA.lengthNotEq(3, [1, 2]), true);
-        eq(RA.lengthNotEq(3, [1, 2, 3]), false);
-        eq(RA.lengthNotEq(0, []), false);
+        assert.isTrue(RA.lengthNotEq(3, [1, 2, 3, 4]));
+        assert.isTrue(RA.lengthNotEq(3, [1, 2]));
+        assert.isFalse(RA.lengthNotEq(3, [1, 2, 3]));
+        assert.isFalse(RA.lengthNotEq(0, []));
       });
     }
   );
@@ -18,28 +19,28 @@ describe('lengthNotEq', function() {
     'given the length of a string is not equal to the supplied length',
     function() {
       specify('should return true', function() {
-        eq(RA.lengthNotEq(3, 'abcd'), true);
-        eq(RA.lengthNotEq(3, 'ab'), true);
-        eq(RA.lengthNotEq(3, 'abc'), false);
-        eq(RA.lengthNotEq(0, ''), false);
+        assert.isTrue(RA.lengthNotEq(3, 'abcd'));
+        assert.isTrue(RA.lengthNotEq(3, 'ab'));
+        assert.isFalse(RA.lengthNotEq(3, 'abc'));
+        assert.isFalse(RA.lengthNotEq(0, ''));
       });
     }
   );
 
   context("given a value doesn't have a length property", function() {
     specify('should return true', function() {
-      eq(RA.lengthNotEq(1, NaN), true);
-      eq(RA.lengthNotEq(1, undefined), true);
-      eq(RA.lengthNotEq(1, null), true);
-      eq(RA.lengthNotEq(1, {}), true);
-      eq(RA.lengthNotEq(1, true), true);
-      eq(RA.lengthNotEq(1, false), true);
-      eq(RA.lengthNotEq(1, 5), true);
+      assert.isTrue(RA.lengthNotEq(1, NaN));
+      assert.isTrue(RA.lengthNotEq(1, undefined));
+      assert.isTrue(RA.lengthNotEq(1, null));
+      assert.isTrue(RA.lengthNotEq(1, {}));
+      assert.isTrue(RA.lengthNotEq(1, true));
+      assert.isTrue(RA.lengthNotEq(1, false));
+      assert.isTrue(RA.lengthNotEq(1, 5));
     });
   });
 
   it('should be curried', function() {
-    eq(RA.lengthNotEq(1, [1, 2]), true);
-    eq(RA.lengthNotEq(1)([1, 2]), true);
+    assert.isTrue(RA.lengthNotEq(1, [1, 2]));
+    assert.isTrue(RA.lengthNotEq(1)([1, 2]));
   });
 });

--- a/test/lensEq.js
+++ b/test/lensEq.js
@@ -1,23 +1,23 @@
+import { assert } from 'chai';
 import { lens, lensIndex, lensPath, lensProp, path } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('lensEq', function() {
   it('tests a lens for a value', function() {
-    eq(RA.lensEq(lensIndex(1), 1, [0, 1]), true);
-    eq(RA.lensEq(lensIndex(0), 1, [0, 1]), false);
-    eq(RA.lensEq(lensPath(['a', 'b']), 'foo', { a: { b: 'foo' } }), true);
-    eq(RA.lensEq(lensPath(['b', 'a']), 'foo', { a: { b: 'foo' } }), false);
-    eq(RA.lensEq(lens(path(['a']), RA.noop), 'b', { a: 'b' }), true);
-    eq(RA.lensEq(lens(path(['a']), RA.noop), 'b', { a: 'c' }), false);
-    eq(RA.lensEq(lensProp('foo'), 'bar', { foo: 'bar' }), true);
-    eq(RA.lensEq(lensProp('foo'), 'bar', { bar: 'foo' }), false);
+    assert.isTrue(RA.lensEq(lensIndex(1), 1, [0, 1]));
+    assert.isFalse(RA.lensEq(lensIndex(0), 1, [0, 1]));
+    assert.isTrue(RA.lensEq(lensPath(['a', 'b']), 'foo', { a: { b: 'foo' } }));
+    assert.isFalse(RA.lensEq(lensPath(['b', 'a']), 'foo', { a: { b: 'foo' } }));
+    assert.isTrue(RA.lensEq(lens(path(['a']), RA.noop), 'b', { a: 'b' }));
+    assert.isFalse(RA.lensEq(lens(path(['a']), RA.noop), 'b', { a: 'c' }));
+    assert.isTrue(RA.lensEq(lensProp('foo'), 'bar', { foo: 'bar' }));
+    assert.isFalse(RA.lensEq(lensProp('foo'), 'bar', { bar: 'foo' }));
   });
 
   it('tests currying', function() {
-    eq(RA.lensEq(lensIndex(1))(1)([0, 1]), true);
-    eq(RA.lensEq(lensIndex(1), 1)([0, 1]), true);
-    eq(RA.lensEq(lensIndex(1))(1, [0, 1]), true);
+    assert.isTrue(RA.lensEq(lensIndex(1))(1)([0, 1]));
+    assert.isTrue(RA.lensEq(lensIndex(1), 1)([0, 1]));
+    assert.isTrue(RA.lensEq(lensIndex(1))(1, [0, 1]));
   });
 });

--- a/test/lensIso.js
+++ b/test/lensIso.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import { view, set, over, assoc, replace } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('lensIso', function() {
   const lensJSON = RA.lensIso(JSON.parse, JSON.stringify);
@@ -9,45 +9,51 @@ describe('lensIso', function() {
   it('tests currying with arity 1', function() {
     const lensJSONA1 = RA.lensIso(JSON.parse)(JSON.stringify);
 
-    eq(view(lensJSONA1, '{"a":1}'), { a: 1 });
+    assert.deepEqual(view(lensJSONA1, '{"a":1}'), { a: 1 });
   });
 
   it('tests currying with arity 2', function() {
-    eq(view(lensJSON, '{"a":1}'), { a: 1 });
+    assert.deepEqual(view(lensJSON, '{"a":1}'), { a: 1 });
   });
 
   it('tests for `from` property', function() {
-    eq(RA.isFunction(RA.lensIso.from), true);
+    assert.isTrue(RA.isFunction(RA.lensIso.from));
   });
 
   it('tests reading through lens', function() {
-    eq(view(lensJSON, '{"a":1}'), { a: 1 });
+    assert.deepEqual(view(lensJSON, '{"a":1}'), { a: 1 });
   });
 
   it('tests writing through lens', function() {
-    eq(set(lensJSON, { b: 2 }, '{"a": 1}'), '{"b":2}');
+    assert.strictEqual(set(lensJSON, { b: 2 }, '{"a": 1}'), '{"b":2}');
   });
 
   it('tests applying a function over lens', function() {
-    eq(over(lensJSON, assoc('b', 2), '{"a":1}'), '{"a":1,"b":2}');
+    assert.strictEqual(
+      over(lensJSON, assoc('b', 2), '{"a":1}'),
+      '{"a":1,"b":2}'
+    );
   });
 
   context('given reversed isomorphism', function() {
     const lensJSONReversed = RA.lensIso.from(lensJSON);
 
     specify('test reading through lens', function() {
-      eq(view(lensJSONReversed, { a: 1 }), '{"a":1}');
+      assert.strictEqual(view(lensJSONReversed, { a: 1 }), '{"a":1}');
     });
 
     specify('tests writing through lens', function() {
-      eq(set(lensJSONReversed, '{"b":2}', { a: 1 }), { b: 2 });
+      assert.deepEqual(set(lensJSONReversed, '{"b":2}', { a: 1 }), { b: 2 });
     });
 
     specify('tests applying a function over lens', function() {
-      eq(over(lensJSONReversed, replace('}', ',"b":2}'), { a: 1 }), {
-        a: 1,
-        b: 2,
-      });
+      assert.deepEqual(
+        over(lensJSONReversed, replace('}', ',"b":2}'), { a: 1 }),
+        {
+          a: 1,
+          b: 2,
+        }
+      );
     });
   });
 });

--- a/test/lensNotEq.js
+++ b/test/lensNotEq.js
@@ -1,23 +1,27 @@
+import { assert } from 'chai';
 import { lens, lensIndex, lensPath, lensProp, path } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('lensNotEq', function() {
   it('tests a lens for a value', function() {
-    eq(RA.lensNotEq(lensIndex(1), 1, [0, 1]), false);
-    eq(RA.lensNotEq(lensIndex(0), 1, [0, 1]), true);
-    eq(RA.lensNotEq(lensPath(['a', 'b']), 'foo', { a: { b: 'foo' } }), false);
-    eq(RA.lensNotEq(lensPath(['b', 'a']), 'foo', { a: { b: 'foo' } }), true);
-    eq(RA.lensNotEq(lens(path(['a']), RA.noop), 'b', { a: 'b' }), false);
-    eq(RA.lensNotEq(lens(path(['a']), RA.noop), 'b', { a: 'c' }), true);
-    eq(RA.lensNotEq(lensProp('foo'), 'bar', { foo: 'bar' }), false);
-    eq(RA.lensNotEq(lensProp('foo'), 'bar', { bar: 'foo' }), true);
+    assert.isFalse(RA.lensNotEq(lensIndex(1), 1, [0, 1]));
+    assert.isTrue(RA.lensNotEq(lensIndex(0), 1, [0, 1]));
+    assert.isFalse(
+      RA.lensNotEq(lensPath(['a', 'b']), 'foo', { a: { b: 'foo' } })
+    );
+    assert.isTrue(
+      RA.lensNotEq(lensPath(['b', 'a']), 'foo', { a: { b: 'foo' } })
+    );
+    assert.isFalse(RA.lensNotEq(lens(path(['a']), RA.noop), 'b', { a: 'b' }));
+    assert.isTrue(RA.lensNotEq(lens(path(['a']), RA.noop), 'b', { a: 'c' }));
+    assert.isFalse(RA.lensNotEq(lensProp('foo'), 'bar', { foo: 'bar' }));
+    assert.isTrue(RA.lensNotEq(lensProp('foo'), 'bar', { bar: 'foo' }));
   });
 
   it('tests currying', function() {
-    eq(RA.lensNotEq(lensIndex(1))(1)([0, 1]), false);
-    eq(RA.lensNotEq(lensIndex(1), 1)([0, 1]), false);
-    eq(RA.lensNotEq(lensIndex(1))(1, [0, 1]), false);
+    assert.isFalse(RA.lensNotEq(lensIndex(1))(1)([0, 1]));
+    assert.isFalse(RA.lensNotEq(lensIndex(1), 1)([0, 1]));
+    assert.isFalse(RA.lensNotEq(lensIndex(1))(1, [0, 1]));
   });
 });

--- a/test/lensNotSatisfy.js
+++ b/test/lensNotSatisfy.js
@@ -1,45 +1,36 @@
+import { assert } from 'chai';
 import { lensIndex, lensPath, lensProp, equals, pathEq } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('lensNotSatisfy', function() {
   it('tests a lens not satisfying the predicate', function() {
-    eq(
-      RA.lensNotSatisfy(equals('bar'), lensProp('foo'), { foo: 'bar' }),
-      false
+    assert.isFalse(
+      RA.lensNotSatisfy(equals('bar'), lensProp('foo'), { foo: 'bar' })
     );
-    eq(RA.lensNotSatisfy(equals('foo'), lensProp('bar'), { foo: 'bar' }), true);
-
-    eq(
-      RA.lensNotSatisfy(x => x > 0, lensIndex(1), [0, 1, 2]),
-      false
-    );
-    eq(
-      RA.lensNotSatisfy(x => x > 0, lensIndex(0), [0, 1, 2]),
-      true
+    assert.isTrue(
+      RA.lensNotSatisfy(equals('foo'), lensProp('bar'), { foo: 'bar' })
     );
 
-    eq(
+    assert.isFalse(RA.lensNotSatisfy(x => x > 0, lensIndex(1), [0, 1, 2]));
+    assert.isTrue(RA.lensNotSatisfy(x => x > 0, lensIndex(0), [0, 1, 2]));
+
+    assert.isFalse(
       RA.lensNotSatisfy(pathEq(['foo', 'bar'], 42), lensPath(['o1', 'o2']), {
         o1: { o2: { foo: { bar: 42 } } },
-      }),
-      false
+      })
     );
   });
 
   it('tests currying', function() {
-    eq(
-      RA.lensNotSatisfy(equals('bar'))(lensProp('foo'))({ foo: 'bar' }),
-      false
+    assert.isFalse(
+      RA.lensNotSatisfy(equals('bar'))(lensProp('foo'))({ foo: 'bar' })
     );
-    eq(
-      RA.lensNotSatisfy(equals('bar'), lensProp('foo'))({ foo: 'bar' }),
-      false
+    assert.isFalse(
+      RA.lensNotSatisfy(equals('bar'), lensProp('foo'))({ foo: 'bar' })
     );
-    eq(
-      RA.lensNotSatisfy(equals('bar'))(lensProp('foo'))({ foo: 'bar' }),
-      false
+    assert.isFalse(
+      RA.lensNotSatisfy(equals('bar'))(lensProp('foo'))({ foo: 'bar' })
     );
   });
 });

--- a/test/lensSatisfies.js
+++ b/test/lensSatisfies.js
@@ -1,33 +1,36 @@
+import { assert } from 'chai';
 import { lensIndex, lensPath, lensProp, equals, pathEq } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('lensSatisfies', function() {
   it('tests a lens satisfying the predicate', function() {
-    eq(RA.lensSatisfies(equals('bar'), lensProp('foo'), { foo: 'bar' }), true);
-    eq(RA.lensSatisfies(equals('foo'), lensProp('bar'), { foo: 'bar' }), false);
-
-    eq(
-      RA.lensSatisfies(x => x > 0, lensIndex(1), [0, 1, 2]),
-      true
+    assert.isTrue(
+      RA.lensSatisfies(equals('bar'), lensProp('foo'), { foo: 'bar' })
     );
-    eq(
-      RA.lensSatisfies(x => x > 0, lensIndex(0), [0, 1, 2]),
-      false
+    assert.isFalse(
+      RA.lensSatisfies(equals('foo'), lensProp('bar'), { foo: 'bar' })
     );
 
-    eq(
+    assert.isTrue(RA.lensSatisfies(x => x > 0, lensIndex(1), [0, 1, 2]));
+    assert.isFalse(RA.lensSatisfies(x => x > 0, lensIndex(0), [0, 1, 2]));
+
+    assert.isTrue(
       RA.lensSatisfies(pathEq(['foo', 'bar'], 42), lensPath(['o1', 'o2']), {
         o1: { o2: { foo: { bar: 42 } } },
-      }),
-      true
+      })
     );
   });
 
   it('tests currying', function() {
-    eq(RA.lensSatisfies(equals('bar'))(lensProp('foo'))({ foo: 'bar' }), true);
-    eq(RA.lensSatisfies(equals('bar'), lensProp('foo'))({ foo: 'bar' }), true);
-    eq(RA.lensSatisfies(equals('bar'))(lensProp('foo'))({ foo: 'bar' }), true);
+    assert.isTrue(
+      RA.lensSatisfies(equals('bar'))(lensProp('foo'))({ foo: 'bar' })
+    );
+    assert.isTrue(
+      RA.lensSatisfies(equals('bar'), lensProp('foo'))({ foo: 'bar' })
+    );
+    assert.isTrue(
+      RA.lensSatisfies(equals('bar'))(lensProp('foo'))({ foo: 'bar' })
+    );
   });
 });

--- a/test/liftF.js
+++ b/test/liftF.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import { Maybe } from 'monet';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 const add3 = (a, b, c) => a + b + c;
 const add4 = (a, b, c, d) => a + b + c + d;
@@ -13,16 +13,19 @@ describe('liftF', function() {
   const addF5 = RA.liftF(add5);
 
   it('returns a function', function() {
-    eq(typeof RA.liftF(add3), 'function');
+    assert.strictEqual(typeof RA.liftF(add3), 'function');
   });
 
   it('can lift functions of any arity', function() {
-    eq(addF3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)), Maybe.Some(3));
-    eq(
+    assert.deepEqual(
+      addF3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+      Maybe.Some(3)
+    );
+    assert.deepEqual(
       addF4(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
       Maybe.Some(4)
     );
-    eq(
+    assert.deepEqual(
       addF5(
         Maybe.Some(1),
         Maybe.Some(1),


### PR DESCRIPTION
Batch 12

test/
- lengthNotEq.js
- lensEq.js
- lensIso.js
- lensNotEq.js
- lensNotSatisfy.js
- lensSatisfies.js
- liftF.js