### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#13

### DIFF
--- a/test/liftFN.js
+++ b/test/liftFN.js
@@ -3,7 +3,6 @@ import { assert } from 'chai';
 import { Maybe } from 'monet';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Identity from '../src/fantasy-land/Identity';
 
 const addN = (...args) => R.sum(args);
@@ -15,11 +14,14 @@ describe('liftFN', function() {
   const addN5 = RA.liftFN(5, addN);
 
   it('returns a function', function() {
-    eq(typeof RA.liftFN(3, add3), 'function');
+    assert.strictEqual(typeof RA.liftFN(3, add3), 'function');
   });
 
   it('limits a variadic function to the specified arity', function() {
-    eq(addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)), Maybe.Some(3));
+    assert.deepEqual(
+      addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+      Maybe.Some(3)
+    );
   });
 
   it('throws error on variadic function is more arguments than arity', function() {
@@ -36,12 +38,15 @@ describe('liftFN', function() {
   });
 
   it('can lift functions of any arity', function() {
-    eq(addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)), Maybe.Some(3));
-    eq(
+    assert.deepEqual(
+      addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+      Maybe.Some(3)
+    );
+    assert.deepEqual(
       addN4(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
       Maybe.Some(4)
     );
-    eq(
+    assert.deepEqual(
       addN5(
         Maybe.Some(1),
         Maybe.Some(1),
@@ -54,11 +59,11 @@ describe('liftFN', function() {
   });
 
   it('retain order of arguments', function() {
-    eq(
+    assert.deepEqual(
       RA.liftFN(3, add3)(Maybe.Some('a'), Maybe.Some('b'), Maybe.Some('c')),
       Maybe.Some('abc')
     );
-    eq(
+    assert.deepEqual(
       RA.liftFN(3, add3)(Identity.of('a'), Identity.of('b'), Identity.of('c')),
       Identity.of('abc')
     );
@@ -66,8 +71,8 @@ describe('liftFN', function() {
 
   it('is curried', function() {
     const f4 = RA.liftFN(4);
-    eq(typeof f4, 'function');
-    eq(
+    assert.strictEqual(typeof f4, 'function');
+    assert.deepEqual(
       f4(addN)(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
       Maybe.Some(4)
     );

--- a/test/liftFN.js
+++ b/test/liftFN.js
@@ -18,9 +18,11 @@ describe('liftFN', function() {
   });
 
   it('limits a variadic function to the specified arity', function() {
-    assert.deepEqual(
-      addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
-      Maybe.Some(3)
+    assert.isTrue(
+      R.equals(
+        addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+        Maybe.Some(3)
+      )
     );
   });
 
@@ -38,43 +40,59 @@ describe('liftFN', function() {
   });
 
   it('can lift functions of any arity', function() {
-    assert.deepEqual(
-      addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
-      Maybe.Some(3)
+    assert.isTrue(
+      R.equals(
+        addN3(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+        Maybe.Some(3)
+      )
     );
-    assert.deepEqual(
-      addN4(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
-      Maybe.Some(4)
+    assert.isTrue(
+      R.equals(
+        addN4(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+        Maybe.Some(4)
+      )
     );
-    assert.deepEqual(
-      addN5(
-        Maybe.Some(1),
-        Maybe.Some(1),
-        Maybe.Some(1),
-        Maybe.Some(1),
-        Maybe.Some(1)
-      ),
-      Maybe.Some(5)
+    assert.isTrue(
+      R.equals(
+        addN5(
+          Maybe.Some(1),
+          Maybe.Some(1),
+          Maybe.Some(1),
+          Maybe.Some(1),
+          Maybe.Some(1)
+        ),
+        Maybe.Some(5)
+      )
     );
   });
 
   it('retain order of arguments', function() {
-    assert.deepEqual(
-      RA.liftFN(3, add3)(Maybe.Some('a'), Maybe.Some('b'), Maybe.Some('c')),
-      Maybe.Some('abc')
+    assert.isTrue(
+      R.equals(
+        RA.liftFN(3, add3)(Maybe.Some('a'), Maybe.Some('b'), Maybe.Some('c')),
+        Maybe.Some('abc')
+      )
     );
-    assert.deepEqual(
-      RA.liftFN(3, add3)(Identity.of('a'), Identity.of('b'), Identity.of('c')),
-      Identity.of('abc')
+    assert.isTrue(
+      R.equals(
+        RA.liftFN(3, add3)(
+          Identity.of('a'),
+          Identity.of('b'),
+          Identity.of('c')
+        ),
+        Identity.of('abc')
+      )
     );
   });
 
   it('is curried', function() {
     const f4 = RA.liftFN(4);
     assert.strictEqual(typeof f4, 'function');
-    assert.deepEqual(
-      f4(addN)(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
-      Maybe.Some(4)
+    assert.isTrue(
+      R.equals(
+        f4(addN)(Maybe.Some(1), Maybe.Some(1), Maybe.Some(1), Maybe.Some(1)),
+        Maybe.Some(4)
+      )
     );
   });
 });

--- a/test/list.js
+++ b/test/list.js
@@ -1,20 +1,21 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('list', function() {
   it('tests creating list from items', function() {
-    eq(RA.list('a', 'b', 'c'), ['a', 'b', 'c']);
+    assert.sameOrderedMembers(RA.list('a', 'b', 'c'), ['a', 'b', 'c']);
   });
 
   it('test creating list from another list', function() {
-    eq(RA.list(['a', 'b']), [['a', 'b']]);
+    assert.sameDeepOrderedMembers(RA.list(['a', 'b']), [['a', 'b']]);
   });
 
   it('test creating list from undefined', function() {
-    eq(RA.list(undefined), [undefined]);
+    assert.sameOrderedMembers(RA.list(undefined), [undefined]);
   });
 
   it('test creating empty list from empty items', function() {
-    eq(RA.list(), []);
+    assert.sameOrderedMembers(RA.list(), []);
   });
 });

--- a/test/mapIndexed.js
+++ b/test/mapIndexed.js
@@ -2,7 +2,6 @@ import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('mapIndexed', function() {
   context('R.map', function() {
@@ -17,16 +16,28 @@ describe('mapIndexed', function() {
     const intoArray = R.into([]);
 
     it('maps simple functions over arrays', function() {
-      eq(RA.mapIndexed(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+      assert.sameOrderedMembers(RA.mapIndexed(times2, [1, 2, 3, 4]), [
+        2,
+        4,
+        6,
+        8,
+      ]);
     });
 
     it('maps simple functions into arrays', function() {
-      eq(intoArray(RA.mapIndexed(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
+      assert.sameOrderedMembers(
+        intoArray(RA.mapIndexed(times2), [1, 2, 3, 4]),
+        [2, 4, 6, 8]
+      );
     });
 
     it('maps over objects', function() {
-      eq(RA.mapIndexed(dec, {}), {});
-      eq(RA.mapIndexed(dec, { x: 4, y: 5, z: 6 }), { x: 3, y: 4, z: 5 });
+      assert.deepEqual(RA.mapIndexed(dec, {}), {});
+      assert.deepEqual(RA.mapIndexed(dec, { x: 4, y: 5, z: 6 }), {
+        x: 3,
+        y: 4,
+        z: 5,
+      });
     });
 
     it('interprets ((->) r) as a functor', function() {
@@ -34,7 +45,7 @@ describe('mapIndexed', function() {
       const g = b => b * 2;
       const h = RA.mapIndexed(f, g);
 
-      eq(h(10), 10 * 2 - 1);
+      assert.strictEqual(h(10), 10 * 2 - 1);
     });
 
     it('dispatches to objects that implement `map`', function() {
@@ -45,14 +56,14 @@ describe('mapIndexed', function() {
         },
       };
 
-      eq(RA.mapIndexed(add1, obj), 101);
+      assert.strictEqual(RA.mapIndexed(add1, obj), 101);
     });
 
     it('dispatches to transformer objects', function() {
       const result = RA.mapIndexed(add1, listXf);
 
-      eq(result.xf, listXf);
-      eq(result.f(41), 42);
+      assert.deepEqual(result.xf, listXf);
+      assert.strictEqual(result.f(41), 42);
     });
 
     it('throws a TypeError on null and undefined', function() {
@@ -68,7 +79,7 @@ describe('mapIndexed', function() {
       const mdouble = RA.mapIndexed(times2);
       const mdec = RA.mapIndexed(dec);
 
-      eq(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
+      assert.sameOrderedMembers(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
     });
 
     it('can compose transducer-style', function() {
@@ -76,9 +87,9 @@ describe('mapIndexed', function() {
       const mdec = RA.mapIndexed(dec);
       const xcomp = mdec(mdouble(listXf));
 
-      eq(xcomp.xf.xf, listXf);
-      eq(xcomp.xf.f(21), 42);
-      eq(xcomp.f(43), 42);
+      assert.deepEqual(xcomp.xf.xf, listXf);
+      assert.strictEqual(xcomp.xf.f(21), 42);
+      assert.strictEqual(xcomp.f(43), 42);
       // eq(xcomp.xf, { xf: listXf, f: times2 });
       // eq(xcomp.f, dec);
     });
@@ -87,7 +98,7 @@ describe('mapIndexed', function() {
       const m1 = RA.Identity.of(1);
       const m2 = RA.mapIndexed(R.add(1), m1);
 
-      eq(m1.value + 1, m2.value);
+      assert.strictEqual(m1.value + 1, m2.value);
     });
   });
 
@@ -96,7 +107,7 @@ describe('mapIndexed', function() {
       const initialList = ['f', 'o', 'o', 'b', 'a', 'r'];
       const resultList = ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r'];
 
-      eq(
+      assert.sameOrderedMembers(
         RA.mapIndexed((val, idx) => `${idx}-${val}`, initialList),
         resultList
       );

--- a/test/mergePath.js
+++ b/test/mergePath.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('mergePath', function() {
   let path;
@@ -15,33 +16,33 @@ describe('mergePath', function() {
   });
 
   it('should curry', function() {
-    eq(RA.mergePath(path, source, obj), expected);
-    eq(RA.mergePath(path)(source, obj), expected);
-    eq(RA.mergePath(path, source)(obj), expected);
-    eq(RA.mergePath(path)(source)(obj), expected);
+    assert.deepEqual(RA.mergePath(path, source, obj), expected);
+    assert.deepEqual(RA.mergePath(path)(source, obj), expected);
+    assert.deepEqual(RA.mergePath(path, source)(obj), expected);
+    assert.deepEqual(RA.mergePath(path)(source)(obj), expected);
   });
 
   it('should merge the property paths containing object', function() {
-    eq(RA.mergePath(path, source, obj), expected);
+    assert.deepEqual(RA.mergePath(path, source, obj), expected);
   });
 
   context('given empty source', function() {
     specify('should return unmodified object', function() {
-      eq(RA.mergePath(path, {}, obj), obj);
+      assert.deepEqual(RA.mergePath(path, {}, obj), obj);
     });
   });
 
   context('given empty obj', function() {
     specify('should create object with subject under path', function() {
       expected = { a: { b: { c2: 22, c3: 33 } } };
-      eq(RA.mergePath(path, source, {}), expected);
+      assert.deepEqual(RA.mergePath(path, source, {}), expected);
     });
   });
 
   context('given target is not an object', function() {
     it('shold create object with subject under path', function() {
       expected = { a: { b: { c2: 22, c3: 33 } } };
-      eq(RA.mergePath(path, source, { a: { b: 1 } }), expected);
+      assert.deepEqual(RA.mergePath(path, source, { a: { b: 1 } }), expected);
     });
   });
 });

--- a/test/mergePaths.js
+++ b/test/mergePaths.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('mergePaths', function() {
   let obj;
@@ -14,23 +15,32 @@ describe('mergePaths', function() {
   });
 
   it('tests currying', function() {
-    eq(RA.mergePaths([['foo', 'fooinner'], ['bar']], obj), expected);
-    eq(RA.mergePaths([['foo', 'fooinner'], ['bar']])(obj), expected);
+    assert.deepEqual(
+      RA.mergePaths([['foo', 'fooinner'], ['bar']], obj),
+      expected
+    );
+    assert.deepEqual(
+      RA.mergePaths([['foo', 'fooinner'], ['bar']])(obj),
+      expected
+    );
   });
 
   it('tests merging the property paths containing object', function() {
-    eq(RA.mergePaths([['foo', 'fooinner'], ['bar']], obj), expected);
+    assert.deepEqual(
+      RA.mergePaths([['foo', 'fooinner'], ['bar']], obj),
+      expected
+    );
   });
 
   it('tests merging the property paths containing non-objects', function() {
-    eq(
+    assert.deepEqual(
       RA.mergePaths([['foo', 'fooinner'], ['bar']], {
         foo: { fooinner: 1 },
         bar: 2,
       }),
       {}
     );
-    eq(
+    assert.deepEqual(
       RA.mergePaths([['foo', 'fooinner'], ['bar']], {
         foo: { fooinner: 'a' },
         bar: 'b',
@@ -39,7 +49,7 @@ describe('mergePaths', function() {
         0: 'b',
       }
     );
-    eq(
+    assert.deepEqual(
       RA.mergePaths([['foo', 'fooinner'], ['bar']], {
         foo: { fooinner: null },
         bar: undefined,
@@ -49,6 +59,6 @@ describe('mergePaths', function() {
   });
 
   it('tests if no paths requested', function() {
-    eq(RA.mergePaths([], obj), {});
+    assert.deepEqual(RA.mergePaths([], obj), {});
   });
 });

--- a/test/mergeProp.js
+++ b/test/mergeProp.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('mergeProp', function() {
   let prop;
@@ -15,33 +16,33 @@ describe('mergeProp', function() {
   });
 
   it('should curry', function() {
-    eq(RA.mergeProp(prop, source, obj), expected);
-    eq(RA.mergeProp(prop)(source, obj), expected);
-    eq(RA.mergeProp(prop, source)(obj), expected);
-    eq(RA.mergeProp(prop)(source)(obj), expected);
+    assert.deepEqual(RA.mergeProp(prop, source, obj), expected);
+    assert.deepEqual(RA.mergeProp(prop)(source, obj), expected);
+    assert.deepEqual(RA.mergeProp(prop, source)(obj), expected);
+    assert.deepEqual(RA.mergeProp(prop)(source)(obj), expected);
   });
 
   it('tests merging the property paths containing object', function() {
-    eq(RA.mergeProp(prop, source, obj), expected);
+    assert.deepEqual(RA.mergeProp(prop, source, obj), expected);
   });
 
   context('given source is empty', function() {
     specify('should return unmodified object', function() {
-      eq(RA.mergeProp(prop, {}, obj), obj);
+      assert.deepEqual(RA.mergeProp(prop, {}, obj), obj);
     });
   });
 
   context('given obj is empty', function() {
     specify('should create object with subject under prop', function() {
       expected = { a: { c2: 22, c3: 33 } };
-      eq(RA.mergeProp(prop, source, {}), expected);
+      assert.deepEqual(RA.mergeProp(prop, source, {}), expected);
     });
   });
 
   context('given target is not an object', function() {
     specify('should create object with subject under prop', function() {
       expected = { a: { c2: 22, c3: 33 } };
-      eq(RA.mergeProp(prop, source, { a: 1 }), expected);
+      assert.deepEqual(RA.mergeProp(prop, source, { a: 1 }), expected);
     });
   });
 });

--- a/test/mergeProps.js
+++ b/test/mergeProps.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('mergeProps', function() {
   let obj;
@@ -14,21 +15,26 @@ describe('mergeProps', function() {
   });
 
   it('tests currying', function() {
-    eq(RA.mergeProps(['foo', 'bar'], obj), expected);
-    eq(RA.mergeProps(['foo', 'bar'])(obj), expected);
+    assert.deepEqual(RA.mergeProps(['foo', 'bar'], obj), expected);
+    assert.deepEqual(RA.mergeProps(['foo', 'bar'])(obj), expected);
   });
 
   it('tests merging the props containing objects', function() {
-    eq(RA.mergeProps(['foo', 'bar'], obj), expected);
+    assert.deepEqual(RA.mergeProps(['foo', 'bar'], obj), expected);
   });
 
   it('tests merging the props containing non-objects', function() {
-    eq(RA.mergeProps(['foo', 'bar'], { foo: 1, bar: 2 }), {});
-    eq(RA.mergeProps(['foo', 'bar'], { foo: 'a', bar: 'b' }), { 0: 'b' });
-    eq(RA.mergeProps(['foo', 'bar'], { foo: null, bar: undefined }), {});
+    assert.deepEqual(RA.mergeProps(['foo', 'bar'], { foo: 1, bar: 2 }), {});
+    assert.deepEqual(RA.mergeProps(['foo', 'bar'], { foo: 'a', bar: 'b' }), {
+      0: 'b',
+    });
+    assert.deepEqual(
+      RA.mergeProps(['foo', 'bar'], { foo: null, bar: undefined }),
+      {}
+    );
   });
 
   it('tests if no props requested', function() {
-    eq(RA.mergeProps([], { foo: 1, bar: 2 }), {});
+    assert.deepEqual(RA.mergeProps([], { foo: 1, bar: 2 }), {});
   });
 });


### PR DESCRIPTION
Batch 13

test/
- liftFN.js
- list.js
- mapIndexed.js
- mergePath.js
- mergePaths.js
- mergeProp.js
- mergeProps.js
