### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#14

### DIFF
--- a/test/mergeRight.js
+++ b/test/mergeRight.js
@@ -1,20 +1,19 @@
-import assert from 'assert';
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('mergeRight', function() {
   it('takes two objects, merges their own properties and returns a new object', function() {
     const a = { w: 1, x: 2 };
     const b = { y: 3, z: 4 };
-    eq(RA.mergeRight(a, b), { w: 1, x: 2, y: 3, z: 4 });
+    assert.deepEqual(RA.mergeRight(a, b), { w: 1, x: 2, y: 3, z: 4 });
   });
 
   it('overrides properties in the seconds object with properties in the first object', function() {
     const a = { w: 1, x: 2 };
     const b = { w: 100, y: 3, z: 4 };
-    eq(RA.mergeRight(b, a), { w: 100, x: 2, y: 3, z: 4 });
+    assert.deepEqual(RA.mergeRight(b, a), { w: 100, x: 2, y: 3, z: 4 });
   });
 
   it('is not destructive', function() {
@@ -22,31 +21,31 @@ describe('mergeRight', function() {
     const res = RA.mergeRight({ x: 5 }, a);
 
     assert.notStrictEqual(a, res);
-    eq(res, { w: 1, x: 5 });
+    assert.deepEqual(res, { w: 1, x: 5 });
   });
 
   it('reports only own properties', function() {
     const a = { w: 1, x: 2 };
     function Cla() {}
     Cla.prototype.x = 5;
-    eq(RA.mergeRight(a, new Cla()), { w: 1, x: 2 });
-    eq(RA.mergeRight(new Cla(), a), { w: 1, x: 2 });
+    assert.deepEqual(RA.mergeRight(a, new Cla()), { w: 1, x: 2 });
+    assert.deepEqual(RA.mergeRight(new Cla(), a), { w: 1, x: 2 });
   });
 
   it('is curried', function() {
     const curried = RA.mergeRight({ w: 1, x: 2 });
     const b = { y: 3, z: 4 };
-    eq(curried(b), { w: 1, x: 2, y: 3, z: 4 });
+    assert.deepEqual(curried(b), { w: 1, x: 2, y: 3, z: 4 });
   });
 
   it('is curried with placeholder', function() {
     const curried = RA.mergeRight({ w: 1, x: 2 }, R.__);
-    eq(curried({ x: 3, y: 4 }), { w: 1, x: 2, y: 4 });
+    assert.deepEqual(curried({ x: 3, y: 4 }), { w: 1, x: 2, y: 4 });
   });
 });
 
 describe('resetToDefault', function() {
   it('tests an alias', function() {
-    eq(RA.mergeRight === RA.resetToDefault, true);
+    assert.strictEqual(RA.mergeRight, RA.resetToDefault);
   });
 });

--- a/test/move.js
+++ b/test/move.js
@@ -1,71 +1,64 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('move', function() {
   const list = ['a', 'b', 'c', 'd', 'e'];
 
   it('should move an item to a higher idx', function() {
     const expected = ['a', 'c', 'd', 'b', 'e'];
-    eq(RA.move(1, 3, list), expected);
+    assert.sameOrderedMembers(RA.move(1, 3, list), expected);
   });
 
   it('should move an item to a lower idx', function() {
     const expected = ['a', 'd', 'b', 'c', 'e'];
-    eq(RA.move(3, 1, list), expected);
+    assert.sameOrderedMembers(RA.move(3, 1, list), expected);
   });
 
   context('given `toIdx` is equal to maximum index', function() {
     specify('should place the item in the final position', function() {
       const expected = ['a', 'c', 'd', 'e', 'b'];
-      eq(RA.move(1, 4, list), expected);
+      assert.sameOrderedMembers(RA.move(1, 4, list), expected);
     });
   });
 
   context('given `toIdx` is greater than maximum idx', function() {
     specify('should place the item in the final position', function() {
       const expected = ['a', 'c', 'd', 'e', 'b'];
-      eq(RA.move(1, 10, list), expected);
+      assert.sameOrderedMembers(RA.move(1, 10, list), expected);
     });
   });
 
   context('given `toIdx` is zero', function() {
     specify('should place the item in the first position', function() {
       const expected = ['b', 'a', 'c', 'd', 'e'];
-      eq(RA.move(1, 0, list), expected);
+      assert.sameOrderedMembers(RA.move(1, 0, list), expected);
     });
   });
 
   context('given `toIdx` is same as `fromIdx', function() {
     specify('should leave item in same position', function() {
-      eq(RA.move(1, 1, list), list);
+      assert.sameOrderedMembers(RA.move(1, 1, list), list);
     });
   });
 
   it('should support currying', function() {
     const expected = ['a', 'c', 'd', 'b', 'e'];
-    eq(RA.move(1)(3, list), expected);
-    eq(RA.move(1, 3)(list), expected);
-    eq(RA.move(1)(3)(list), expected);
+    assert.sameOrderedMembers(RA.move(1)(3, list), expected);
+    assert.sameOrderedMembers(RA.move(1, 3)(list), expected);
+    assert.sameOrderedMembers(RA.move(1)(3)(list), expected);
   });
 
   context('given `fromIdx` is greater than maximum index', function() {
     specify('should place `undefined` in newIdx position', function() {
       const expected = ['a', 'b', undefined, 'c', 'd', 'e'];
-      eq(RA.move(6, 2, list), expected);
+      assert.sameOrderedMembers(RA.move(6, 2, list), expected);
     });
   });
 
   it('should treat nested lists like any other items', function() {
-    const listOfLists = [
-      ['a', 'b'],
-      ['c', 'd'],
-      ['e', 'f'],
-    ];
-    const expected = [
-      ['e', 'f'],
-      ['a', 'b'],
-      ['c', 'd'],
-    ];
-    eq(RA.move(2)(0, listOfLists), expected);
+    const listOfLists = [['a', 'b'], ['c', 'd'], ['e', 'f']];
+    const expected = [['e', 'f'], ['a', 'b'], ['c', 'd']];
+    assert.sameDeepOrderedMembers(RA.move(2)(0, listOfLists), expected);
   });
 });

--- a/test/move.js
+++ b/test/move.js
@@ -57,8 +57,16 @@ describe('move', function() {
   });
 
   it('should treat nested lists like any other items', function() {
-    const listOfLists = [['a', 'b'], ['c', 'd'], ['e', 'f']];
-    const expected = [['e', 'f'], ['a', 'b'], ['c', 'd']];
+    const listOfLists = [
+      ['a', 'b'],
+      ['c', 'd'],
+      ['e', 'f'],
+    ];
+    const expected = [
+      ['e', 'f'],
+      ['a', 'b'],
+      ['c', 'd'],
+    ];
     assert.sameDeepOrderedMembers(RA.move(2)(0, listOfLists), expected);
   });
 });

--- a/test/neither.js
+++ b/test/neither.js
@@ -1,9 +1,9 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 import { Just, Nothing } from 'monet';
 import sinon from 'sinon';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 const supportsFantasyLand = () => {
   try {
@@ -21,10 +21,10 @@ describe('neither', function() {
     const gt10 = x => x > 10;
     const f = RA.neither(even, gt10);
 
-    eq(f(8), false);
-    eq(f(13), false);
-    eq(f(14), false);
-    eq(f(9), true);
+    assert.isFalse(f(8));
+    assert.isFalse(f(13));
+    assert.isFalse(f(14));
+    assert.isTrue(f(9));
   });
 
   it('accepts functions that take multiple parameters', function() {
@@ -32,10 +32,10 @@ describe('neither', function() {
     const total20 = (a, b, c) => a + b + c === 20;
     const f = RA.neither(between, total20);
 
-    eq(f(4, 5, 11), false);
-    eq(f(12, 2, 6), false);
-    eq(f(5, 6, 15), false);
-    eq(f(12, 2, 7), true);
+    assert.isFalse(f(4, 5, 11));
+    assert.isFalse(f(12, 2, 6));
+    assert.isFalse(f(5, 6, 15));
+    assert.isTrue(f(12, 2, 7));
   });
 
   context('given the result of first function is true', function() {
@@ -43,21 +43,21 @@ describe('neither', function() {
       const z = sinon.spy();
 
       RA.neither(R.T, z)();
-      eq(z.notCalled, true);
+      assert.isTrue(z.notCalled);
     });
   });
 
   if (isFantasyLandSupported) {
     it('accepts fantasy-land applicative functors', function() {
-      eq(RA.neither(Just(true), Just(true)), Just(false));
-      eq(RA.neither(Just(true), Just(false)), Just(false));
-      eq(RA.neither(Just(false), Just(true)), Just(false));
-      eq(RA.neither(Just(false), Just(false)), Just(true));
-      eq(RA.neither(Just(true), Nothing()), Nothing());
-      eq(RA.neither(Nothing(), Just(true)), Nothing());
-      eq(RA.neither(Nothing(), Just(false)), Nothing());
-      eq(RA.neither(Just(false), Nothing()), Nothing());
-      eq(RA.neither(Nothing(), Nothing()), Nothing());
+      assert.isTrue(R.equals(RA.neither(Just(true), Just(true)), Just(false)));
+      assert.isTrue(R.equals(RA.neither(Just(true), Just(false)), Just(false)));
+      assert.isTrue(R.equals(RA.neither(Just(false), Just(true)), Just(false)));
+      assert.isTrue(R.equals(RA.neither(Just(false), Just(false)), Just(true)));
+      assert.isTrue(R.equals(RA.neither(Just(true), Nothing()), Nothing()));
+      assert.isTrue(R.equals(RA.neither(Nothing(), Just(true)), Nothing()));
+      assert.isTrue(R.equals(RA.neither(Nothing(), Just(false)), Nothing()));
+      assert.isTrue(R.equals(RA.neither(Just(false), Nothing()), Nothing()));
+      assert.isTrue(R.equals(RA.neither(Nothing(), Nothing()), Nothing()));
     });
   }
 });

--- a/test/noneP.js
+++ b/test/noneP.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 const delay = (ms = 0) => new Promise(res => setTimeout(res, ms));
 
@@ -14,7 +14,7 @@ describe('noneP', function() {
         RA.rejectP(),
       ]);
 
-      eq(reasons, [1, 'b', undefined]);
+      assert.sameOrderedMembers(reasons, [1, 'b', undefined]);
     });
   });
 
@@ -26,7 +26,7 @@ describe('noneP', function() {
         RA.resolveP('oops'),
       ]).then(RA.rejectP, R.identity);
 
-      eq(value, 'oops');
+      assert.strictEqual(value, 'oops');
     });
   });
 
@@ -40,7 +40,7 @@ describe('noneP', function() {
           delay(10).then(() => RA.resolveP('fast')),
         ]).then(RA.rejectP, R.identity);
 
-        eq(value, 'fast');
+        assert.strictEqual(value, 'fast');
       }
     );
   });
@@ -55,7 +55,7 @@ describe('noneP', function() {
           RA.resolveP(3),
         ]).then(RA.rejectP, R.identity);
 
-        eq(value, 1);
+        assert.strictEqual(value, 1);
       }
     );
   });
@@ -67,7 +67,7 @@ describe('noneP', function() {
         R.identity
       );
 
-      eq(value, 2);
+      assert.strictEqual(value, 2);
     });
   });
 
@@ -75,7 +75,7 @@ describe('noneP', function() {
     specify('should resolve with empty reasons', async function() {
       const value = await RA.noneP([]);
 
-      eq(value, []);
+      assert.sameOrderedMembers(value, []);
     });
   });
 
@@ -87,6 +87,6 @@ describe('noneP', function() {
     const actual = [p1, v2, p3];
     const expected = [1, 2, 3];
 
-    eq(await noneP(actual), expected);
+    assert.sameOrderedMembers(await noneP(actual), expected);
   });
 });

--- a/test/nonePass.js
+++ b/test/nonePass.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('nonePass', function() {
   const odd = n => n % 2 !== 0;
@@ -9,23 +10,23 @@ describe('nonePass', function() {
 
   it('reports whether all predicates are satisfied by a given value', function() {
     const ok = RA.nonePass([odd, divBy3, lt20]);
-    eq(ok(9), false); // all ps succeed
-    eq(ok(12), false); // p1 fails
-    eq(ok(7), false); // p2 fails
-    eq(ok(21), false); // p3 fails
-    eq(ok(2), false); // p1 and p2 fails
-    eq(ok(18), false); // p1 and p3 fails
-    eq(ok(23), false); // p2 and p3 fails
-    eq(ok(26), true); // all ps fail
+    assert.isFalse(ok(9)); // all ps succeed
+    assert.isFalse(ok(12)); // p1 fails
+    assert.isFalse(ok(7)); // p2 fails
+    assert.isFalse(ok(21)); // p3 fails
+    assert.isFalse(ok(2)); // p1 and p2 fails
+    assert.isFalse(ok(18)); // p1 and p3 fails
+    assert.isFalse(ok(23)); // p2 and p3 fails
+    assert.isTrue(ok(26)); // all ps fail
   });
 
   it('returns true on empty predicate list', function() {
-    eq(RA.nonePass([])(3), true);
+    assert.isTrue(RA.nonePass([])(3));
   });
 
   it('returns a curried function whose arity matches that of the highest-arity predicate', function() {
-    eq(RA.nonePass([odd, divBy3, plusEq]).length, 4);
-    eq(RA.nonePass([odd, divBy3, plusEq])(26, 26, 26, 28), true);
-    eq(RA.nonePass([odd, divBy3, plusEq])(26)(26)(26)(28), true);
+    assert.strictEqual(RA.nonePass([odd, divBy3, plusEq]).length, 4);
+    assert.isTrue(RA.nonePass([odd, divBy3, plusEq])(26, 26, 26, 28));
+    assert.isTrue(RA.nonePass([odd, divBy3, plusEq])(26)(26)(26)(28));
   });
 });


### PR DESCRIPTION
Batch 14

test/
- mergeRight.js
- move.js
- neither.js
- noneP.js
- nonePass.js