### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#16

### DIFF
--- a/test/padCharsEnd.js
+++ b/test/padCharsEnd.js
@@ -1,34 +1,35 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
 import { padEndInvoker, padEndPolyfill } from '../src/padCharsEnd';
-import eq from './shared/eq';
 
 describe('padCharsEnd', function() {
   specify('should pad string with given padString', function() {
-    eq(RA.padCharsEnd('-', 3, 'a'), 'a--');
+    assert.strictEqual(RA.padCharsEnd('-', 3, 'a'), 'a--');
   });
 
   context('given targetLength as 0', function() {
     specify('should return original string', function() {
-      eq(RA.padCharsEnd('$', 0, 'abc'), 'abc');
+      assert.strictEqual(RA.padCharsEnd('$', 0, 'abc'), 'abc');
     });
   });
 
   context('given targetLength less than string length', function() {
     specify('should return original string', function() {
-      eq(RA.padCharsEnd('$', 1, 'abc'), 'abc');
+      assert.strictEqual(RA.padCharsEnd('$', 1, 'abc'), 'abc');
     });
   });
 
   context('given targetLength less than equal to padString length', function() {
     specify('should trim padString', function() {
-      eq(RA.padCharsEnd('123456', 6, 'abc'), 'abc123');
-      eq(RA.padCharsEnd('123456', 5, 'abc'), 'abc12');
+      assert.strictEqual(RA.padCharsEnd('123456', 6, 'abc'), 'abc123');
+      assert.strictEqual(RA.padCharsEnd('123456', 5, 'abc'), 'abc12');
     });
   });
 
   context('given targetLength supplied as float', function() {
     specify('should convert targetLength to integer', function() {
-      eq(RA.padCharsEnd('$', 7.5, 'abc'), 'abc$$$$');
+      assert.strictEqual(RA.padCharsEnd('$', 7.5, 'abc'), 'abc$$$$');
     });
   });
 
@@ -36,34 +37,34 @@ describe('padCharsEnd', function() {
     'given targetLength is a value coercible to valid integer number',
     function() {
       specify('should return padded string', function() {
-        eq(RA.padCharsEnd('*', '5', 'abc'), 'abc**');
+        assert.strictEqual(RA.padCharsEnd('*', '5', 'abc'), 'abc**');
       });
     }
   );
 
   context('given targeLength is a negative number', function() {
     specify('should return original string', function() {
-      eq(RA.padCharsEnd('$', -10, 'abc'), 'abc');
+      assert.strictEqual(RA.padCharsEnd('$', -10, 'abc'), 'abc');
     });
   });
 
   context('given padString set to undefined', function() {
     specify('should return string padded with spaces', function() {
-      eq(RA.padCharsEnd(undefined, 5, '200'), '200  ');
+      assert.strictEqual(RA.padCharsEnd(undefined, 5, '200'), '200  ');
     });
   });
 
   context('given null padString', function() {
     specify('should convert null to string type', function() {
-      eq(RA.padCharsEnd(null, 5, 'abc'), 'abcnu');
+      assert.strictEqual(RA.padCharsEnd(null, 5, 'abc'), 'abcnu');
     });
   });
 
   specify('should curry', function() {
-    eq(RA.padCharsEnd('*', 5, 'abc'), 'abc**');
-    eq(RA.padCharsEnd('*', 5)('abc'), 'abc**');
-    eq(RA.padCharsEnd('*')(5, 'abc'), 'abc**');
-    eq(RA.padCharsEnd('*')(5)('abc'), 'abc**');
+    assert.strictEqual(RA.padCharsEnd('*', 5, 'abc'), 'abc**');
+    assert.strictEqual(RA.padCharsEnd('*', 5)('abc'), 'abc**');
+    assert.strictEqual(RA.padCharsEnd('*')(5, 'abc'), 'abc**');
+    assert.strictEqual(RA.padCharsEnd('*')(5)('abc'), 'abc**');
   });
 
   context('padEndInvoker', function() {
@@ -74,18 +75,18 @@ describe('padCharsEnd', function() {
     });
 
     specify('should pad string with given padString', function() {
-      eq(padEndInvoker('-', 3, 'a'), 'a--');
+      assert.strictEqual(padEndInvoker('-', 3, 'a'), 'a--');
     });
 
     context('given targetLength as 0', function() {
       specify('should return original string', function() {
-        eq(padEndInvoker('$', 0, 'abc'), 'abc');
+        assert.strictEqual(padEndInvoker('$', 0, 'abc'), 'abc');
       });
     });
 
     context('given targetLength less than string length', function() {
       specify('should return original string', function() {
-        eq(padEndInvoker('$', 1, 'abc'), 'abc');
+        assert.strictEqual(padEndInvoker('$', 1, 'abc'), 'abc');
       });
     });
 
@@ -93,15 +94,15 @@ describe('padCharsEnd', function() {
       'given targetLength less than equal to padString length',
       function() {
         specify('should trim padString', function() {
-          eq(padEndInvoker('123456', 6, 'abc'), 'abc123');
-          eq(padEndInvoker('123456', 5, 'abc'), 'abc12');
+          assert.strictEqual(padEndInvoker('123456', 6, 'abc'), 'abc123');
+          assert.strictEqual(padEndInvoker('123456', 5, 'abc'), 'abc12');
         });
       }
     );
 
     context('given targetLength supplied as float', function() {
       specify('should convert targetLength to integer', function() {
-        eq(padEndInvoker('$', 7.5, 'abc'), 'abc$$$$');
+        assert.strictEqual(padEndInvoker('$', 7.5, 'abc'), 'abc$$$$');
       });
     });
 
@@ -109,51 +110,51 @@ describe('padCharsEnd', function() {
       'given targetLength is a value coercible to valid integer number',
       function() {
         specify('should return padded string', function() {
-          eq(padEndInvoker('*', '5', 'abc'), 'abc**');
+          assert.strictEqual(padEndInvoker('*', '5', 'abc'), 'abc**');
         });
       }
     );
 
     context('given targeLength is a negative number', function() {
       specify('should return original string', function() {
-        eq(padEndInvoker('$', -10, 'abc'), 'abc');
+        assert.strictEqual(padEndInvoker('$', -10, 'abc'), 'abc');
       });
     });
 
     context('given padString set to undefined', function() {
       specify('should return string padded with spaces', function() {
-        eq(padEndInvoker(undefined, 5, '200'), '200  ');
+        assert.strictEqual(padEndInvoker(undefined, 5, '200'), '200  ');
       });
     });
 
     context('given null padString', function() {
       specify('should convert null to string type', function() {
-        eq(padEndInvoker(null, 5, 'abc'), 'abcnu');
+        assert.strictEqual(padEndInvoker(null, 5, 'abc'), 'abcnu');
       });
     });
 
     specify('should curry', function() {
-      eq(padEndInvoker('*', 5, 'abc'), 'abc**');
-      eq(padEndInvoker('*', 5)('abc'), 'abc**');
-      eq(padEndInvoker('*')(5, 'abc'), 'abc**');
-      eq(padEndInvoker('*')(5)('abc'), 'abc**');
+      assert.strictEqual(padEndInvoker('*', 5, 'abc'), 'abc**');
+      assert.strictEqual(padEndInvoker('*', 5)('abc'), 'abc**');
+      assert.strictEqual(padEndInvoker('*')(5, 'abc'), 'abc**');
+      assert.strictEqual(padEndInvoker('*')(5)('abc'), 'abc**');
     });
   });
 
   context('padEndPolyfill', function() {
     specify('should pad string with given padString', function() {
-      eq(padEndPolyfill('-', 3, 'a'), 'a--');
+      assert.strictEqual(padEndPolyfill('-', 3, 'a'), 'a--');
     });
 
     context('given targetLength as 0', function() {
       specify('should return original string', function() {
-        eq(padEndPolyfill('$', 0, 'abc'), 'abc');
+        assert.strictEqual(padEndPolyfill('$', 0, 'abc'), 'abc');
       });
     });
 
     context('given targetLength less than string length', function() {
       specify('should return original string', function() {
-        eq(padEndPolyfill('$', 1, 'abc'), 'abc');
+        assert.strictEqual(padEndPolyfill('$', 1, 'abc'), 'abc');
       });
     });
 
@@ -161,15 +162,15 @@ describe('padCharsEnd', function() {
       'given targetLength less than equal to padString length',
       function() {
         specify('should trim padString', function() {
-          eq(padEndPolyfill('123456', 6, 'abc'), 'abc123');
-          eq(padEndPolyfill('123456', 5, 'abc'), 'abc12');
+          assert.strictEqual(padEndPolyfill('123456', 6, 'abc'), 'abc123');
+          assert.strictEqual(padEndPolyfill('123456', 5, 'abc'), 'abc12');
         });
       }
     );
 
     context('given targetLength supplied as float', function() {
       specify('should convert targetLength to integer', function() {
-        eq(padEndPolyfill('$', 7.5, 'abc'), 'abc$$$$');
+        assert.strictEqual(padEndPolyfill('$', 7.5, 'abc'), 'abc$$$$');
       });
     });
 
@@ -177,34 +178,34 @@ describe('padCharsEnd', function() {
       'given targetLength is a value coercible to valid integer number',
       function() {
         specify('should return padded string', function() {
-          eq(padEndPolyfill('*', '5', 'abc'), 'abc**');
+          assert.strictEqual(padEndPolyfill('*', '5', 'abc'), 'abc**');
         });
       }
     );
 
     context('given targeLength is a negative number', function() {
       specify('should return original string', function() {
-        eq(padEndPolyfill('$', -10, 'abc'), 'abc');
+        assert.strictEqual(padEndPolyfill('$', -10, 'abc'), 'abc');
       });
     });
 
     context('given padString set to undefined', function() {
       specify('should return string padded with spaces', function() {
-        eq(padEndPolyfill(undefined, 5, '200'), '200  ');
+        assert.strictEqual(padEndPolyfill(undefined, 5, '200'), '200  ');
       });
     });
 
     context('given null padString', function() {
       specify('should convert null to string type', function() {
-        eq(padEndPolyfill(null, 5, 'abc'), 'abcnu');
+        assert.strictEqual(padEndPolyfill(null, 5, 'abc'), 'abcnu');
       });
     });
 
     specify('should curry', function() {
-      eq(padEndPolyfill('*', 5, 'abc'), 'abc**');
-      eq(padEndPolyfill('*', 5)('abc'), 'abc**');
-      eq(padEndPolyfill('*')(5, 'abc'), 'abc**');
-      eq(padEndPolyfill('*')(5)('abc'), 'abc**');
+      assert.strictEqual(padEndPolyfill('*', 5, 'abc'), 'abc**');
+      assert.strictEqual(padEndPolyfill('*', 5)('abc'), 'abc**');
+      assert.strictEqual(padEndPolyfill('*')(5, 'abc'), 'abc**');
+      assert.strictEqual(padEndPolyfill('*')(5)('abc'), 'abc**');
     });
   });
 });

--- a/test/padCharsStart.js
+++ b/test/padCharsStart.js
@@ -1,34 +1,35 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 import { padStartInvoker, padStartPolyfill } from '../src/padCharsStart';
 
 describe('padCharsStart', function() {
   specify('should pad string with given padString', function() {
-    eq(RA.padCharsStart('-', 3, 'a'), '--a');
+    assert.strictEqual(RA.padCharsStart('-', 3, 'a'), '--a');
   });
 
   context('given targetLength as 0', function() {
     specify('should return original string', function() {
-      eq(RA.padCharsStart('-', 0, 'abc'), 'abc');
+      assert.strictEqual(RA.padCharsStart('-', 0, 'abc'), 'abc');
     });
   });
 
   context('given targetLength less than string length', function() {
     specify('should return original string', function() {
-      eq(RA.padCharsStart('-', 1, 'abc'), 'abc');
+      assert.strictEqual(RA.padCharsStart('-', 1, 'abc'), 'abc');
     });
   });
 
   context('given targetLength less than equal to padString length', function() {
     specify('should trim padString', function() {
-      eq(RA.padCharsStart('123456', 6, 'abc'), '123abc');
-      eq(RA.padCharsStart('123456', 5, 'abc'), '12abc');
+      assert.strictEqual(RA.padCharsStart('123456', 6, 'abc'), '123abc');
+      assert.strictEqual(RA.padCharsStart('123456', 5, 'abc'), '12abc');
     });
   });
 
   context('given targetLength supplied as float', function() {
     specify('should convert targetLength to integer', function() {
-      eq(RA.padCharsStart('-', 7.5, 'abc'), '----abc');
+      assert.strictEqual(RA.padCharsStart('-', 7.5, 'abc'), '----abc');
     });
   });
 
@@ -36,34 +37,34 @@ describe('padCharsStart', function() {
     'given targetLength is a value coercible to valid integer number',
     function() {
       specify('should return padded string', function() {
-        eq(RA.padCharsStart('-', '5', 'abc'), '--abc');
+        assert.strictEqual(RA.padCharsStart('-', '5', 'abc'), '--abc');
       });
     }
   );
 
   context('given targeLength is a negative number', function() {
     specify('should return original string', function() {
-      eq(RA.padCharsStart('-', -10, 'abc'), 'abc');
+      assert.strictEqual(RA.padCharsStart('-', -10, 'abc'), 'abc');
     });
   });
 
   context('given padString set to undefined', function() {
     specify('should return string padded with spaces', function() {
-      eq(RA.padCharsStart(undefined, 5, '200'), '  200');
+      assert.strictEqual(RA.padCharsStart(undefined, 5, '200'), '  200');
     });
   });
 
   context('given null padString', function() {
     specify('should convert null to string type', function() {
-      eq(RA.padCharsStart(null, 5, 'abc'), 'nuabc');
+      assert.strictEqual(RA.padCharsStart(null, 5, 'abc'), 'nuabc');
     });
   });
 
   specify('should curry', function() {
-    eq(RA.padCharsStart('-', 5, 'abc'), '--abc');
-    eq(RA.padCharsStart('-', 5)('abc'), '--abc');
-    eq(RA.padCharsStart('-')(5, 'abc'), '--abc');
-    eq(RA.padCharsStart('-')(5)('abc'), '--abc');
+    assert.strictEqual(RA.padCharsStart('-', 5, 'abc'), '--abc');
+    assert.strictEqual(RA.padCharsStart('-', 5)('abc'), '--abc');
+    assert.strictEqual(RA.padCharsStart('-')(5, 'abc'), '--abc');
+    assert.strictEqual(RA.padCharsStart('-')(5)('abc'), '--abc');
   });
 
   context('padStartInvoker', function() {
@@ -74,18 +75,18 @@ describe('padCharsStart', function() {
     });
 
     specify('should pad string with given padString', function() {
-      eq(padStartInvoker('-', 3, 'a'), '--a');
+      assert.strictEqual(padStartInvoker('-', 3, 'a'), '--a');
     });
 
     context('given targetLength as 0', function() {
       specify('should return original string', function() {
-        eq(padStartInvoker('-', 0, 'abc'), 'abc');
+        assert.strictEqual(padStartInvoker('-', 0, 'abc'), 'abc');
       });
     });
 
     context('given targetLength less than string length', function() {
       specify('should return original string', function() {
-        eq(padStartInvoker('-', 1, 'abc'), 'abc');
+        assert.strictEqual(padStartInvoker('-', 1, 'abc'), 'abc');
       });
     });
 
@@ -93,15 +94,15 @@ describe('padCharsStart', function() {
       'given targetLength less than equal to padString length',
       function() {
         specify('should trim padString', function() {
-          eq(padStartInvoker('123456', 6, 'abc'), '123abc');
-          eq(padStartInvoker('123456', 5, 'abc'), '12abc');
+          assert.strictEqual(padStartInvoker('123456', 6, 'abc'), '123abc');
+          assert.strictEqual(padStartInvoker('123456', 5, 'abc'), '12abc');
         });
       }
     );
 
     context('given targetLength supplied as float', function() {
       specify('should convert targetLength to integer', function() {
-        eq(padStartInvoker('-', 7.5, 'abc'), '----abc');
+        assert.strictEqual(padStartInvoker('-', 7.5, 'abc'), '----abc');
       });
     });
 
@@ -109,51 +110,51 @@ describe('padCharsStart', function() {
       'given targetLength is a value coercible to valid integer number',
       function() {
         specify('should return padded string', function() {
-          eq(padStartInvoker('-', '5', 'abc'), '--abc');
+          assert.strictEqual(padStartInvoker('-', '5', 'abc'), '--abc');
         });
       }
     );
 
     context('given targeLength is a negative number', function() {
       specify('should return original string', function() {
-        eq(padStartInvoker('-', -10, 'abc'), 'abc');
+        assert.strictEqual(padStartInvoker('-', -10, 'abc'), 'abc');
       });
     });
 
     context('given padString set to undefined', function() {
       specify('should return string padded with spaces', function() {
-        eq(padStartInvoker(undefined, 5, '200'), '  200');
+        assert.strictEqual(padStartInvoker(undefined, 5, '200'), '  200');
       });
     });
 
     context('given null padString', function() {
       specify('should convert null to string type', function() {
-        eq(padStartInvoker(null, 5, 'abc'), 'nuabc');
+        assert.strictEqual(padStartInvoker(null, 5, 'abc'), 'nuabc');
       });
     });
 
     specify('should curry', function() {
-      eq(padStartInvoker('-', 5, 'abc'), '--abc');
-      eq(padStartInvoker('-', 5)('abc'), '--abc');
-      eq(padStartInvoker('-')(5, 'abc'), '--abc');
-      eq(padStartInvoker('-')(5)('abc'), '--abc');
+      assert.strictEqual(padStartInvoker('-', 5, 'abc'), '--abc');
+      assert.strictEqual(padStartInvoker('-', 5)('abc'), '--abc');
+      assert.strictEqual(padStartInvoker('-')(5, 'abc'), '--abc');
+      assert.strictEqual(padStartInvoker('-')(5)('abc'), '--abc');
     });
   });
 
   context('padStartPolyfill', function() {
     specify('should pad string with given padString', function() {
-      eq(padStartPolyfill('-', 3, 'a'), '--a');
+      assert.strictEqual(padStartPolyfill('-', 3, 'a'), '--a');
     });
 
     context('given targetLength as 0', function() {
       specify('should return original string', function() {
-        eq(padStartPolyfill('-', 0, 'abc'), 'abc');
+        assert.strictEqual(padStartPolyfill('-', 0, 'abc'), 'abc');
       });
     });
 
     context('given targetLength less than string length', function() {
       specify('should return original string', function() {
-        eq(padStartPolyfill('-', 1, 'abc'), 'abc');
+        assert.strictEqual(padStartPolyfill('-', 1, 'abc'), 'abc');
       });
     });
 
@@ -161,15 +162,15 @@ describe('padCharsStart', function() {
       'given targetLength less than equal to padString length',
       function() {
         specify('should trim padString', function() {
-          eq(padStartPolyfill('123456', 6, 'abc'), '123abc');
-          eq(padStartPolyfill('123456', 5, 'abc'), '12abc');
+          assert.strictEqual(padStartPolyfill('123456', 6, 'abc'), '123abc');
+          assert.strictEqual(padStartPolyfill('123456', 5, 'abc'), '12abc');
         });
       }
     );
 
     context('given targetLength supplied as float', function() {
       specify('should convert targetLength to integer', function() {
-        eq(padStartPolyfill('-', 7.5, 'abc'), '----abc');
+        assert.strictEqual(padStartPolyfill('-', 7.5, 'abc'), '----abc');
       });
     });
 
@@ -177,34 +178,34 @@ describe('padCharsStart', function() {
       'given targetLength is a value coercible to valid integer number',
       function() {
         specify('should return padded string', function() {
-          eq(padStartPolyfill('-', '5', 'abc'), '--abc');
+          assert.strictEqual(padStartPolyfill('-', '5', 'abc'), '--abc');
         });
       }
     );
 
     context('given targeLength is a negative number', function() {
       specify('should return original string', function() {
-        eq(padStartPolyfill('-', -10, 'abc'), 'abc');
+        assert.strictEqual(padStartPolyfill('-', -10, 'abc'), 'abc');
       });
     });
 
     context('given padString set to undefined', function() {
       specify('should return string padded with spaces', function() {
-        eq(padStartPolyfill(undefined, 5, '200'), '  200');
+        assert.strictEqual(padStartPolyfill(undefined, 5, '200'), '  200');
       });
     });
 
     context('given null padString', function() {
       specify('should convert null to string type', function() {
-        eq(padStartPolyfill(null, 5, 'abc'), 'nuabc');
+        assert.strictEqual(padStartPolyfill(null, 5, 'abc'), 'nuabc');
       });
     });
 
     specify('should curry', function() {
-      eq(padStartPolyfill('-', 5, 'abc'), '--abc');
-      eq(padStartPolyfill('-', 5)('abc'), '--abc');
-      eq(padStartPolyfill('-')(5, 'abc'), '--abc');
-      eq(padStartPolyfill('-')(5)('abc'), '--abc');
+      assert.strictEqual(padStartPolyfill('-', 5, 'abc'), '--abc');
+      assert.strictEqual(padStartPolyfill('-', 5)('abc'), '--abc');
+      assert.strictEqual(padStartPolyfill('-')(5, 'abc'), '--abc');
+      assert.strictEqual(padStartPolyfill('-')(5)('abc'), '--abc');
     });
   });
 });

--- a/test/padEnd.js
+++ b/test/padEnd.js
@@ -1,26 +1,27 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('padEnd', function() {
   specify('should pad string with spaces', function() {
-    eq(RA.padEnd(3, 'a'), 'a  ');
+    assert.strictEqual(RA.padEnd(3, 'a'), 'a  ');
   });
 
   context('given targetLength as 0', function() {
     specify('should return original string', function() {
-      eq(RA.padEnd(0, 'abc'), 'abc');
+      assert.strictEqual(RA.padEnd(0, 'abc'), 'abc');
     });
   });
 
   context('given targetLength less than string length', function() {
     specify('should return original string', function() {
-      eq(RA.padEnd(1, 'abc'), 'abc');
+      assert.strictEqual(RA.padEnd(1, 'abc'), 'abc');
     });
   });
 
   context('given targetLength supplied as float', function() {
     specify('should convert targetLength to integer', function() {
-      eq(RA.padEnd(7.5, 'abc'), 'abc    ');
+      assert.strictEqual(RA.padEnd(7.5, 'abc'), 'abc    ');
     });
   });
 
@@ -28,19 +29,19 @@ describe('padEnd', function() {
     'given targetLength is a value coercible to valid integer number',
     function() {
       specify('should return padded string', function() {
-        eq(RA.padEnd('5', 'abc'), 'abc  ');
+        assert.strictEqual(RA.padEnd('5', 'abc'), 'abc  ');
       });
     }
   );
 
   context('given targeLength is a negative number', function() {
     specify('should return original string', function() {
-      eq(RA.padEnd(-10, 'abc'), 'abc');
+      assert.strictEqual(RA.padEnd(-10, 'abc'), 'abc');
     });
   });
 
   specify('should curry', function() {
-    eq(RA.padEnd(5, 'abc'), 'abc  ');
-    eq(RA.padEnd(5)('abc'), 'abc  ');
+    assert.strictEqual(RA.padEnd(5, 'abc'), 'abc  ');
+    assert.strictEqual(RA.padEnd(5)('abc'), 'abc  ');
   });
 });

--- a/test/pathNotEq.js
+++ b/test/pathNotEq.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('pathNotEq', function() {
   let obj;
@@ -11,18 +11,18 @@ describe('pathNotEq', function() {
   });
 
   it('should curry', function() {
-    eq(RA.pathNotEq(['a', 'b'], 'foo', obj), true);
-    eq(RA.pathNotEq(['a', 'b'])('foo', obj), true);
-    eq(RA.pathNotEq(['a', 'b'], 'foo')(obj), true);
-    eq(RA.pathNotEq(['a', 'b'])('foo')(obj), true);
+    assert.isTrue(RA.pathNotEq(['a', 'b'], 'foo', obj));
+    assert.isTrue(RA.pathNotEq(['a', 'b'])('foo', obj));
+    assert.isTrue(RA.pathNotEq(['a', 'b'], 'foo')(obj));
+    assert.isTrue(RA.pathNotEq(['a', 'b'])('foo')(obj));
   });
 
   it('tests path value is not equal', function() {
-    eq(RA.pathNotEq(['a', 'b'], 'foo', obj), true);
+    assert.isTrue(RA.pathNotEq(['a', 'b'], 'foo', obj));
   });
 
   it('tests path value is equal', function() {
-    eq(RA.pathNotEq(['a', 'b'], 1, obj), false);
+    assert.isFalse(RA.pathNotEq(['a', 'b'], 1, obj));
   });
 
   it('has R.equals semantics', function() {
@@ -33,18 +33,17 @@ describe('pathNotEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    eq(RA.pathNotEq(['a', 'b'], 0, { a: { b: -0 } }), true);
-    eq(RA.pathNotEq(['a', 'b'], -0, { a: { b: 0 } }), true);
-    eq(RA.pathNotEq(['a', 'b'], NaN, { a: { b: NaN } }), false);
-    eq(
-      RA.pathNotEq(['a', 'b'], new Just([42]), { a: { b: new Just([42]) } }),
-      false
+    assert.isTrue(RA.pathNotEq(['a', 'b'], 0, { a: { b: -0 } }));
+    assert.isTrue(RA.pathNotEq(['a', 'b'], -0, { a: { b: 0 } }));
+    assert.isFalse(RA.pathNotEq(['a', 'b'], NaN, { a: { b: NaN } }));
+    assert.isFalse(
+      RA.pathNotEq(['a', 'b'], new Just([42]), { a: { b: new Just([42]) } })
     );
   });
 
   context('given there is no path', function() {
     specify('should return true', function() {
-      eq(RA.pathNotEq(['bar', 'baz'], 'foo', obj), true);
+      assert.isTrue(RA.pathNotEq(['bar', 'baz'], 'foo', obj));
     });
   });
 
@@ -59,7 +58,7 @@ describe('pathNotEq', function() {
       });
 
       specify('should return false', function() {
-        eq(RA.pathNotEq([0, 1], 'b', obj), false);
+        assert.isFalse(RA.pathNotEq([0, 1], 'b', obj));
       });
     });
 
@@ -73,7 +72,7 @@ describe('pathNotEq', function() {
       });
 
       specify('should return true', function() {
-        eq(RA.pathNotEq([999, 999], 'x', obj), true);
+        assert.isTrue(RA.pathNotEq([999, 999], 'x', obj));
       });
     });
   });
@@ -86,6 +85,6 @@ describe('pathNotEq', function() {
     const isFamous = RA.pathNotEq(['address', 'zipCode'], 90210);
     const result = R.filter(isFamous, users); //= > [ user2, user3 ]
 
-    eq(result, [user2, user3]);
+    assert.sameDeepOrderedMembers(result, [user2, user3]);
   });
 });

--- a/test/pathOrLazy.js
+++ b/test/pathOrLazy.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import sinon from 'sinon';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('pathOrLazy', function() {
   const obj = {
@@ -13,7 +13,7 @@ describe('pathOrLazy', function() {
 
   context('given requested path exists', function() {
     specify('should return value at path', function() {
-      eq(
+      assert.strictEqual(
         RA.pathOrLazy(() => {}, ['a', 'b', 'c'], obj),
         1
       );
@@ -22,14 +22,14 @@ describe('pathOrLazy', function() {
     specify('should not invoke lazy function', function() {
       const fn = sinon.spy();
       RA.pathOrLazy(fn, ['a', 'b', 'c'], obj);
-      eq(fn.notCalled, true);
+      assert.isTrue(fn.notCalled);
     });
   });
 
   context('given requested path does not exist', function() {
     context('and the value is missing', function() {
       specify('should return default value', function() {
-        eq(
+        assert.strictEqual(
           RA.pathOrLazy(() => 7, ['nonexistent'], obj),
           7
         );
@@ -38,7 +38,7 @@ describe('pathOrLazy', function() {
 
     context('and the value is NaN', function() {
       specify('should return default value', function() {
-        eq(
+        assert.strictEqual(
           RA.pathOrLazy(() => 7, ['e'], obj),
           7
         );
@@ -47,7 +47,7 @@ describe('pathOrLazy', function() {
 
     context('and the value is null', function() {
       specify('should return default value', function() {
-        eq(
+        assert.strictEqual(
           RA.pathOrLazy(() => 7, ['f'], obj),
           7
         );
@@ -56,7 +56,7 @@ describe('pathOrLazy', function() {
 
     context('and the value is undefined', function() {
       specify('should return default value', function() {
-        eq(
+        assert.strictEqual(
           RA.pathOrLazy(() => 7, ['g'], obj),
           7
         );
@@ -66,15 +66,15 @@ describe('pathOrLazy', function() {
     specify('should pass object to lazy function as only argument', function() {
       const fn = sinon.spy();
       RA.pathOrLazy(fn, ['nonexistent'], obj);
-      eq(fn.calledOnceWithExactly(obj), true);
+      assert.isTrue(fn.calledOnceWithExactly(obj));
     });
   });
 
   it('should curry', function() {
     const fn = () => 7;
-    eq(RA.pathOrLazy(fn, ['a', 'b', 'd', 1], obj), 'y');
-    eq(RA.pathOrLazy(fn)(['a', 'b', 'd', 1], obj), 'y');
-    eq(RA.pathOrLazy(fn, ['a', 'b', 'd', 1])(obj), 'y');
-    eq(RA.pathOrLazy(fn)(['a', 'b', 'd', 1])(obj), 'y');
+    assert.strictEqual(RA.pathOrLazy(fn, ['a', 'b', 'd', 1], obj), 'y');
+    assert.strictEqual(RA.pathOrLazy(fn)(['a', 'b', 'd', 1], obj), 'y');
+    assert.strictEqual(RA.pathOrLazy(fn, ['a', 'b', 'd', 1])(obj), 'y');
+    assert.strictEqual(RA.pathOrLazy(fn)(['a', 'b', 'd', 1])(obj), 'y');
   });
 });


### PR DESCRIPTION
Batch 16

test/
- padCharsEnd.js
- padCharsStart.js
- padEnd.js
- pathNotEq.js
- pathOrLazy.js
