### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#17

### DIFF
--- a/test/paths.js
+++ b/test/paths.js
@@ -1,29 +1,34 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('paths', function() {
   const obj = { a: { b: { c: 1 } }, d: 4, e: 5, f: 6 };
 
   it('returns empty array if no paths requested', function() {
-    eq(RA.paths([], obj), []);
+    assert.sameOrderedMembers(RA.paths([], obj), []);
   });
 
   it('returns values for requested paths', function() {
-    eq(RA.paths([['a', 'b', 'c'], ['e']], obj), [1, 5]);
+    assert.sameOrderedMembers(RA.paths([['a', 'b', 'c'], ['e']], obj), [1, 5]);
   });
 
   it('preserves order', function() {
-    eq(RA.paths([['f'], ['a', 'b', 'c'], ['e']], obj), [6, 1, 5]);
+    assert.sameOrderedMembers(RA.paths([['f'], ['a', 'b', 'c'], ['e']], obj), [
+      6,
+      1,
+      5,
+    ]);
   });
 
   it('returns undefined for nonexistent paths', function() {
     const ps = RA.paths([['d'], ['nonexistent']], obj);
-    eq(ps.length, 2);
-    eq(ps[0], 4);
-    eq(ps[1], undefined);
+    assert.lengthOf(ps, 2);
+    assert.strictEqual(ps[0], 4);
+    assert.isUndefined(ps[1]);
   });
 
   it('is curried', function() {
-    eq(RA.paths([['a', 'b', 'c'], ['d']])(obj), [1, 4]);
+    assert.sameOrderedMembers(RA.paths([['a', 'b', 'c'], ['d']])(obj), [1, 4]);
   });
 });

--- a/test/pickIndexes.js
+++ b/test/pickIndexes.js
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('pickIndexes', function() {
   let list;
@@ -11,17 +10,17 @@ describe('pickIndexes', function() {
   });
 
   it('tests currying', function() {
-    eq(RA.pickIndexes([], []), []);
-    eq(RA.pickIndexes([])([]), []);
+    assert.sameOrderedMembers(RA.pickIndexes([], []), []);
+    assert.sameOrderedMembers(RA.pickIndexes([])([]), []);
   });
 
   it('tests picking values from list by indexes', function() {
-    eq(RA.pickIndexes([0, 2], list), ['a', 'c']);
+    assert.sameOrderedMembers(RA.pickIndexes([0, 2], list), ['a', 'c']);
   });
 
   context("given indexes doesn't exist", function() {
     specify('should skip these indexes', function() {
-      eq(RA.pickIndexes([-1, 0, 5], list), ['a']);
+      assert.sameOrderedMembers(RA.pickIndexes([-1, 0, 5], list), ['a']);
     });
   });
 
@@ -39,19 +38,19 @@ describe('pickIndexes', function() {
 
   context('given empty indexes', function() {
     specify('should return empty array', function() {
-      eq(RA.pickIndexes([], list), []);
+      assert.sameOrderedMembers(RA.pickIndexes([], list), []);
     });
   });
 
   context('given empty list', function() {
     specify('should return empty array', function() {
-      eq(RA.pickIndexes([0, 1, 2], []), []);
+      assert.sameOrderedMembers(RA.pickIndexes([0, 1, 2], []), []);
     });
   });
 
   context('given empty indexes and list', function() {
     specify('should return empty array', function() {
-      eq(RA.pickIndexes([], []), []);
+      assert.sameOrderedMembers(RA.pickIndexes([], []), []);
     });
   });
 });

--- a/test/propNotEq.js
+++ b/test/propNotEq.js
@@ -1,7 +1,7 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('propNotEq', function() {
   let obj;
@@ -11,18 +11,18 @@ describe('propNotEq', function() {
   });
 
   it('tests currying', function() {
-    eq(RA.propNotEq('a', 'foo', obj), true);
-    eq(RA.propNotEq('a')('foo', obj), true);
-    eq(RA.propNotEq('a', 'foo')(obj), true);
-    eq(RA.propNotEq('a')('foo')(obj), true);
+    assert.isTrue(RA.propNotEq('a', 'foo', obj));
+    assert.isTrue(RA.propNotEq('a')('foo', obj));
+    assert.isTrue(RA.propNotEq('a', 'foo')(obj));
+    assert.isTrue(RA.propNotEq('a')('foo')(obj));
   });
 
   it('tests prop value is not equal', function() {
-    eq(RA.propNotEq('a', 'foo', obj), true);
+    assert.isTrue(RA.propNotEq('a', 'foo', obj));
   });
 
   it('tests prop value is equal', function() {
-    eq(RA.propNotEq('a', 1, obj), false);
+    assert.isFalse(RA.propNotEq('a', 1, obj));
   });
 
   it('has R.equals semantics', function() {
@@ -33,15 +33,17 @@ describe('propNotEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    eq(RA.propNotEq('value', 0, { value: -0 }), true);
-    eq(RA.propNotEq('value', -0, { value: 0 }), true);
-    eq(RA.propNotEq('value', NaN, { value: NaN }), false);
-    eq(RA.propNotEq('value', new Just([42]), { value: new Just([42]) }), false);
+    assert.isTrue(RA.propNotEq('value', 0, { value: -0 }));
+    assert.isTrue(RA.propNotEq('value', -0, { value: 0 }));
+    assert.isFalse(RA.propNotEq('value', NaN, { value: NaN }));
+    assert.isFalse(
+      RA.propNotEq('value', new Just([42]), { value: new Just([42]) })
+    );
   });
 
   context('given there is no prop bar', function() {
     specify('should return true', function() {
-      eq(RA.propNotEq('bar', 'foo', obj), true);
+      assert.isTrue(RA.propNotEq('bar', 'foo', obj));
     });
   });
 
@@ -53,7 +55,7 @@ describe('propNotEq', function() {
       });
 
       specify('should return false', function() {
-        eq(RA.propNotEq(0, 'a', obj), false);
+        assert.isFalse(RA.propNotEq(0, 'a', obj));
       });
     });
 
@@ -64,7 +66,7 @@ describe('propNotEq', function() {
       });
 
       specify('should return true', function() {
-        eq(RA.propNotEq(0, 'x', obj), true);
+        assert.isTrue(RA.propNotEq(0, 'x', obj));
       });
     });
   });

--- a/test/reduceIndexed.js
+++ b/test/reduceIndexed.js
@@ -2,7 +2,6 @@ import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('reduceIndexed', function() {
   context('R.reduce', function() {
@@ -10,8 +9,8 @@ describe('reduceIndexed', function() {
     const mult = (a, b) => a * b;
 
     it('folds simple functions over arrays with the supplied accumulator', function() {
-      eq(R.reduce(addition, 0, [1, 2, 3, 4]), 10);
-      eq(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
+      assert.strictEqual(R.reduce(addition, 0, [1, 2, 3, 4]), 10);
+      assert.strictEqual(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
     });
 
     it('dispatches to objects that implement `reduce`', function() {
@@ -22,14 +21,14 @@ describe('reduceIndexed', function() {
         },
       };
 
-      eq(R.reduce(addition, 0, obj), 'override');
-      eq(R.reduce(addition, 10, obj), 'override');
+      assert.strictEqual(R.reduce(addition, 0, obj), 'override');
+      assert.strictEqual(R.reduce(addition, 10, obj), 'override');
     });
 
     it('returns the accumulator for an empty array', function() {
-      eq(R.reduce(addition, 0, []), 0);
-      eq(R.reduce(mult, 1, []), 1);
-      eq(R.reduce(R.concat, [], []), []);
+      assert.strictEqual(R.reduce(addition, 0, []), 0);
+      assert.strictEqual(R.reduce(mult, 1, []), 1);
+      assert.sameOrderedMembers(R.reduce(R.concat, [], []), []);
     });
 
     it('uses the iterator of an object (and handles short-circuits)', function() {
@@ -68,7 +67,7 @@ describe('reduceIndexed', function() {
       const rfn = xf(apendingT);
       const list = new Reducible([1, 2, 3, 4, 5, 6]);
 
-      eq(R.reduce(rfn, [], list), [1, 2]);
+      assert.sameOrderedMembers(R.reduce(rfn, [], list), [1, 2]);
     });
   });
 
@@ -77,7 +76,7 @@ describe('reduceIndexed', function() {
       const initialList = ['f', 'o', 'o', 'b', 'a', 'r'];
       const resultAcc = '-f0-o1-o2-b3-a4-r5';
 
-      eq(
+      assert.strictEqual(
         RA.reduceIndexed(
           (acc, val, idx) => `${acc}-${val}${idx}`,
           '',

--- a/test/reduceP.js
+++ b/test/reduceP.js
@@ -1,16 +1,16 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 import sinon from 'sinon';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('reduceP', function() {
   it('folds simple functions over arrays with the supplied accumulator', function() {
     const testAdd = RA.reduceP(R.add, 0, [1, 2, 3, 4]).then(actual =>
-      eq(actual, 10)
+      assert.strictEqual(actual, 10)
     );
     const testMultiply = RA.reduceP(R.multiply, 1, [1, 2, 3, 4]).then(actual =>
-      eq(actual, 24)
+      assert.strictEqual(actual, 24)
     );
 
     return Promise.all([testAdd, testMultiply]);
@@ -24,22 +24,24 @@ describe('reduceP', function() {
       },
     };
     const test1 = RA.reduceP(R.add, 0, obj).then(actual =>
-      eq(actual, 'override')
+      assert.strictEqual(actual, 'override')
     );
     const test2 = RA.reduceP(R.add, 10, obj).then(actual =>
-      eq(actual, 'override')
+      assert.strictEqual(actual, 'override')
     );
 
     return Promise.all([test1, test2]);
   });
 
   it('returns the accumulator for an empty array', function() {
-    const testAdd = RA.reduceP(R.add, 0, []).then(actual => eq(actual, 0));
+    const testAdd = RA.reduceP(R.add, 0, []).then(actual => 
+      assert.strictEqual(actual, 0)
+    );
     const testMultiply = RA.reduceP(R.multiply, 1, []).then(actual =>
-      eq(actual, 1)
+      assert.strictEqual(actual, 1)
     );
     const testConcat = RA.reduceP(R.concat, [], []).then(actual =>
-      eq(actual, [])
+      assert.sameOrderedMembers(actual, [])
     );
 
     return Promise.all([testAdd, testMultiply, testConcat]);
@@ -49,9 +51,11 @@ describe('reduceP', function() {
     const sum = RA.reduceP(R.add)(0);
     const cat = RA.reduceP(R.concat)('');
 
-    const testSum = sum([1, 2, 3, 4]).then(actual => eq(actual, 10));
+    const testSum = sum([1, 2, 3, 4]).then(actual => 
+      assert.strictEqual(actual, 10)
+    );
     const testConcat = cat(['1', '2', '3', '4']).then(actual =>
-      eq(actual, '1234')
+      assert.strictEqual(actual, '1234')
     );
 
     return Promise.all([testSum, testConcat]);
@@ -59,7 +63,7 @@ describe('reduceP', function() {
 
   it('correctly reports the arity of curried versions', function() {
     const sum = RA.reduceP(R.add, 0);
-    eq(sum.length, 1);
+    assert.strictEqual(sum.length, 1);
   });
 
   it('tests initial value for promise', function() {
@@ -68,13 +72,13 @@ describe('reduceP', function() {
       2,
       3,
       4,
-    ]).then(actual => eq(actual, 10));
+    ]).then(actual => assert.strictEqual(actual, 10));
     const testMultiply = RA.reduceP(R.multiply, Promise.resolve(1), [
       1,
       2,
       3,
       4,
-    ]).then(actual => eq(actual, 24));
+    ]).then(actual => assert.strictEqual(actual, 24));
 
     return Promise.all([testAdd, testMultiply]);
   });
@@ -84,8 +88,8 @@ describe('reduceP', function() {
       const add = sinon.spy();
 
       return RA.reduceP(add, 0, [])
-        .then(actual => eq(actual, 0))
-        .then(() => eq(add.called, false));
+        .then(actual => assert.strictEqual(actual, 0))
+        .then(() => assert.isFalse(add.called));
     });
   });
 
@@ -94,8 +98,8 @@ describe('reduceP', function() {
       const add = sinon.spy();
 
       return RA.reduceP(add, Promise.resolve(0), [])
-        .then(actual => eq(actual, 0))
-        .then(() => eq(add.called, false));
+        .then(actual => assert.strictEqual(actual, 0))
+        .then(() => assert.isFalse(add.called));
     });
   });
 
@@ -103,27 +107,27 @@ describe('reduceP', function() {
     const add = sinon.spy();
 
     return RA.reduceP(add, undefined, [1])
-      .then(actual => eq(actual, 1))
-      .then(() => eq(add.called, false));
+      .then(actual => assert.strictEqual(actual, 1))
+      .then(() => assert.isFalse(add.called));
   });
 
   it('tests if initial value is undefined (promise version)', function() {
     const add = sinon.spy();
 
     return RA.reduceP(add, Promise.resolve(), [1])
-      .then(actual => eq(actual, 1))
-      .then(() => eq(add.called, false));
+      .then(actual => assert.strictEqual(actual, 1))
+      .then(() => assert.isFalse(add.called));
   });
 
   it('tests iterator wrapped in the promise', function() {
     return RA.reduceP(R.add, 0, Promise.resolve([1, 2, 3])).then(actual =>
-      eq(actual, 6)
+      assert.strictEqual(actual, 6)
     );
   });
 
   it('tests iterator containing values and promises', function() {
     return RA.reduceP(R.add, 0, [1, Promise.resolve(2), 3]).then(actual =>
-      eq(actual, 6)
+      assert.strictEqual(actual, 6)
     );
   });
 
@@ -132,7 +136,7 @@ describe('reduceP', function() {
       R.add,
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
-    ).then(actual => eq(actual, 6));
+    ).then(actual => assert.strictEqual(actual, 6));
   });
 
   it('tests iterator function returning promises', function() {
@@ -140,7 +144,7 @@ describe('reduceP', function() {
       R.pipe(R.add, Promise.resolve.bind(Promise)),
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
-    ).then(actual => eq(actual, 6));
+    ).then(actual => assert.strictEqual(actual, 6));
   });
 
   it('prefers the use of the iterator of an object over reduce (and handles short-circuits)', function() {

--- a/test/reduceP.js
+++ b/test/reduceP.js
@@ -34,7 +34,7 @@ describe('reduceP', function() {
   });
 
   it('returns the accumulator for an empty array', function() {
-    const testAdd = RA.reduceP(R.add, 0, []).then(actual => 
+    const testAdd = RA.reduceP(R.add, 0, []).then(actual =>
       assert.strictEqual(actual, 0)
     );
     const testMultiply = RA.reduceP(R.multiply, 1, []).then(actual =>
@@ -51,7 +51,7 @@ describe('reduceP', function() {
     const sum = RA.reduceP(R.add)(0);
     const cat = RA.reduceP(R.concat)('');
 
-    const testSum = sum([1, 2, 3, 4]).then(actual => 
+    const testSum = sum([1, 2, 3, 4]).then(actual =>
       assert.strictEqual(actual, 10)
     );
     const testConcat = cat(['1', '2', '3', '4']).then(actual =>


### PR DESCRIPTION
Batch 17

test/
- paths.js
- pickIndexes.js
- propNotEq.js
- reduceIndexed.js
- reduceP.js