### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#18

### DIFF
--- a/test/reduceRightP.js
+++ b/test/reduceRightP.js
@@ -1,20 +1,22 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 import sinon from 'sinon';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('reduceRightP', function() {
   it('folds simple functions over arrays with the supplied accumulator', function() {
     const testAdd = RA.reduceRightP(R.add, 0, [1, 2, 3, 4]).then(actual =>
-      eq(actual, 10)
+      assert.strictEqual(actual, 10)
     );
     const testMultiply = RA.reduceRightP(R.multiply, 1, [
       1,
       2,
       3,
       4,
-    ]).then(actual => eq(actual, 24));
+    ]).then(actual =>
+        assert.strictEqual(actual, 24)
+      );
 
     return Promise.all([testAdd, testMultiply]);
   });
@@ -26,21 +28,23 @@ describe('reduceRightP', function() {
         return 'override';
       },
     };
-    const test1 = RA.reduceRightP(R.add, 0, obj).then(actual => eq(actual, 0));
+    const test1 = RA.reduceRightP(R.add, 0, obj).then(actual =>
+      assert.strictEqual(actual, 0));
     const test2 = RA.reduceRightP(R.add, 10, obj).then(actual =>
-      eq(actual, 10)
+      assert.strictEqual(actual, 10)
     );
 
     return Promise.all([test1, test2]);
   });
 
   it('returns the accumulator for an empty array', function() {
-    const testAdd = RA.reduceRightP(R.add, 0, []).then(actual => eq(actual, 0));
+    const testAdd = RA.reduceRightP(R.add, 0, []).then(actual =>
+      assert.strictEqual(actual, 0));
     const testMultiply = RA.reduceRightP(R.multiply, 1, []).then(actual =>
-      eq(actual, 1)
+      assert.strictEqual(actual, 1)
     );
     const testConcat = RA.reduceRightP(R.concat, [], []).then(actual =>
-      eq(actual, [])
+      assert.sameOrderedMembers(actual, [])
     );
 
     return Promise.all([testAdd, testMultiply, testConcat]);
@@ -50,9 +54,10 @@ describe('reduceRightP', function() {
     const sum = RA.reduceRightP(R.add)(0);
     const cat = RA.reduceRightP(R.concat)('');
 
-    const testSum = sum([1, 2, 3, 4]).then(actual => eq(actual, 10));
+    const testSum = sum([1, 2, 3, 4]).then(actual =>
+      assert.strictEqual(actual, 10));
     const testConcat = cat(['1', '2', '3', '4']).then(actual =>
-      eq(actual, '1234')
+      assert.strictEqual(actual, '1234')
     );
 
     return Promise.all([testSum, testConcat]);
@@ -60,7 +65,7 @@ describe('reduceRightP', function() {
 
   it('correctly reports the arity of curried versions', function() {
     const sum = RA.reduceRightP(R.add, 0);
-    eq(sum.length, 1);
+    assert.strictEqual(sum.length, 1);
   });
 
   it('tests initial value for promise', function() {
@@ -69,13 +74,13 @@ describe('reduceRightP', function() {
       2,
       3,
       4,
-    ]).then(actual => eq(actual, 10));
+    ]).then(actual => assert.strictEqual(actual, 10));
     const testMultiply = RA.reduceRightP(R.multiply, Promise.resolve(1), [
       1,
       2,
       3,
       4,
-    ]).then(actual => eq(actual, 24));
+    ]).then(actual => assert.strictEqual(actual, 24));
 
     return Promise.all([testAdd, testMultiply]);
   });
@@ -85,8 +90,8 @@ describe('reduceRightP', function() {
       const add = sinon.spy();
 
       return RA.reduceRightP(add, 0, [])
-        .then(actual => eq(actual, 0))
-        .then(() => eq(add.called, false));
+        .then(actual => assert.strictEqual(actual, 0))
+        .then(() => assert.isFalse(add.called));
     });
   });
 
@@ -95,8 +100,8 @@ describe('reduceRightP', function() {
       const add = sinon.spy();
 
       return RA.reduceRightP(add, Promise.resolve(0), [])
-        .then(actual => eq(actual, 0))
-        .then(() => eq(add.called, false));
+        .then(actual => assert.strictEqual(actual, 0))
+        .then(() => assert.isFalse(add.called));
     });
   });
 
@@ -104,27 +109,27 @@ describe('reduceRightP', function() {
     const add = sinon.spy();
 
     return RA.reduceRightP(add, undefined, [1])
-      .then(actual => eq(actual, 1))
-      .then(() => eq(add.called, false));
+      .then(actual => assert.strictEqual(actual, 1))
+      .then(() => assert.isFalse(add.called));
   });
 
   it('tests if initial value is undefined (promise version)', function() {
     const add = sinon.spy();
 
     return RA.reduceRightP(add, Promise.resolve(), [1])
-      .then(actual => eq(actual, 1))
-      .then(() => eq(add.called, false));
+      .then(actual => assert.strictEqual(actual, 1))
+      .then(() => assert.isFalse(add.called));
   });
 
   it('tests iterator wrapped in the promise', function() {
     return RA.reduceRightP(R.add, 0, Promise.resolve([1, 2, 3])).then(actual =>
-      eq(actual, 6)
+      assert.strictEqual(actual, 6)
     );
   });
 
   it('tests iterator containing values and promises', function() {
     return RA.reduceRightP(R.add, 0, [1, Promise.resolve(2), 3]).then(actual =>
-      eq(actual, 6)
+      assert.strictEqual(actual, 6)
     );
   });
 
@@ -133,7 +138,7 @@ describe('reduceRightP', function() {
       R.add,
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
-    ).then(actual => eq(actual, 6));
+    ).then(actual => assert.strictEqual(actual, 6));
   });
 
   it('tests iterator function returning promises', function() {
@@ -141,7 +146,7 @@ describe('reduceRightP', function() {
       R.pipe(R.add, Promise.resolve.bind(Promise)),
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
-    ).then(actual => eq(actual, 6));
+    ).then(actual => assert.strictEqual(actual, 6));
   });
 
   it('tests difference between reduceRightP reduceP', function() {
@@ -150,17 +155,17 @@ describe('reduceRightP', function() {
     const catRightFlipped = RA.reduceRightP(R.flip(R.concat))('');
 
     const testCat = cat(['1', '2', '3', '4']).then(actual =>
-      eq(actual, '1234')
+      assert.strictEqual(actual, '1234')
     );
     const testCatRight = catRight(['1', '2', '3', '4']).then(actual =>
-      eq(actual, '1234')
+      assert.strictEqual(actual, '1234')
     );
     const testCatRightFlipped = catRightFlipped([
       '1',
       '2',
       '3',
       '4',
-    ]).then(actual => eq(actual, '4321'));
+    ]).then(actual => assert.strictEqual(actual, '4321'));
 
     return Promise.all([testCat, testCatRight, testCatRightFlipped]);
   });

--- a/test/reduceRightP.js
+++ b/test/reduceRightP.js
@@ -6,15 +6,15 @@ import * as RA from '../src';
 
 describe('reduceRightP', function() {
   it('folds simple functions over arrays with the supplied accumulator', function() {
-    const testAdd = RA.reduceRightP(R.add, 0, [
+    const testAdd = RA.reduceRightP(R.add, 0, [1, 2, 3, 4]).then(actual =>
+      assert.strictEqual(actual, 10)
+    );
+    const testMultiply = RA.reduceRightP(R.multiply, 1, [
       1,
       2,
       3,
-      4
-    ]).then(actual => assert.strictEqual(actual, 10));
-    const testMultiply = RA.reduceRightP(R.multiply, 1, [1, 2, 3, 4]).then(
-      actual => assert.strictEqual(actual, 24)
-    );
+      4,
+    ]).then(actual => assert.strictEqual(actual, 24));
 
     return Promise.all([testAdd, testMultiply]);
   });
@@ -144,9 +144,7 @@ describe('reduceRightP', function() {
 
   it('tests iterator function returning promises', function() {
     return RA.reduceRightP(
-      R.pipe(
-        R.add, Promise.resolve.bind(Promise)
-      ),
+      R.pipe(R.add, Promise.resolve.bind(Promise)),
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
     ).then(actual => assert.strictEqual(actual, 6));
@@ -167,9 +165,8 @@ describe('reduceRightP', function() {
       '1',
       '2',
       '3',
-      '4'
-    ]).then(actual => assert.strictEqual(actual, '4321')
-    );
+      '4',
+    ]).then(actual => assert.strictEqual(actual, '4321'));
 
     return Promise.all([testCat, testCatRight, testCatRightFlipped]);
   });

--- a/test/reduceRightP.js
+++ b/test/reduceRightP.js
@@ -6,9 +6,12 @@ import * as RA from '../src';
 
 describe('reduceRightP', function() {
   it('folds simple functions over arrays with the supplied accumulator', function() {
-    const testAdd = RA.reduceRightP(R.add, 0, [1, 2, 3, 4]).then(actual =>
-      assert.strictEqual(actual, 10)
-    );
+    const testAdd = RA.reduceRightP(R.add, 0, [
+      1,
+      2,
+      3,
+      4
+    ]).then(actual => assert.strictEqual(actual, 10));
     const testMultiply = RA.reduceRightP(R.multiply, 1, [1, 2, 3, 4]).then(
       actual => assert.strictEqual(actual, 24)
     );
@@ -142,8 +145,7 @@ describe('reduceRightP', function() {
   it('tests iterator function returning promises', function() {
     return RA.reduceRightP(
       R.pipe(
-        R.add,
-        Promise.resolve.bind(Promise)
+        R.add, Promise.resolve.bind(Promise)
       ),
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
@@ -161,8 +163,12 @@ describe('reduceRightP', function() {
     const testCatRight = catRight(['1', '2', '3', '4']).then(actual =>
       assert.strictEqual(actual, '1234')
     );
-    const testCatRightFlipped = catRightFlipped(['1', '2', '3', '4']).then(
-      actual => assert.strictEqual(actual, '4321')
+    const testCatRightFlipped = catRightFlipped([
+      '1',
+      '2',
+      '3',
+      '4'
+    ]).then(actual => assert.strictEqual(actual, '4321')
     );
 
     return Promise.all([testCat, testCatRight, testCatRightFlipped]);

--- a/test/reduceRightP.js
+++ b/test/reduceRightP.js
@@ -9,14 +9,9 @@ describe('reduceRightP', function() {
     const testAdd = RA.reduceRightP(R.add, 0, [1, 2, 3, 4]).then(actual =>
       assert.strictEqual(actual, 10)
     );
-    const testMultiply = RA.reduceRightP(R.multiply, 1, [
-      1,
-      2,
-      3,
-      4,
-    ]).then(actual =>
-        assert.strictEqual(actual, 24)
-      );
+    const testMultiply = RA.reduceRightP(R.multiply, 1, [1, 2, 3, 4]).then(
+      actual => assert.strictEqual(actual, 24)
+    );
 
     return Promise.all([testAdd, testMultiply]);
   });
@@ -29,7 +24,8 @@ describe('reduceRightP', function() {
       },
     };
     const test1 = RA.reduceRightP(R.add, 0, obj).then(actual =>
-      assert.strictEqual(actual, 0));
+      assert.strictEqual(actual, 0)
+    );
     const test2 = RA.reduceRightP(R.add, 10, obj).then(actual =>
       assert.strictEqual(actual, 10)
     );
@@ -39,7 +35,8 @@ describe('reduceRightP', function() {
 
   it('returns the accumulator for an empty array', function() {
     const testAdd = RA.reduceRightP(R.add, 0, []).then(actual =>
-      assert.strictEqual(actual, 0));
+      assert.strictEqual(actual, 0)
+    );
     const testMultiply = RA.reduceRightP(R.multiply, 1, []).then(actual =>
       assert.strictEqual(actual, 1)
     );
@@ -55,7 +52,8 @@ describe('reduceRightP', function() {
     const cat = RA.reduceRightP(R.concat)('');
 
     const testSum = sum([1, 2, 3, 4]).then(actual =>
-      assert.strictEqual(actual, 10));
+      assert.strictEqual(actual, 10)
+    );
     const testConcat = cat(['1', '2', '3', '4']).then(actual =>
       assert.strictEqual(actual, '1234')
     );
@@ -143,7 +141,10 @@ describe('reduceRightP', function() {
 
   it('tests iterator function returning promises', function() {
     return RA.reduceRightP(
-      R.pipe(R.add, Promise.resolve.bind(Promise)),
+      R.pipe(
+        R.add,
+        Promise.resolve.bind(Promise)
+      ),
       0,
       Promise.resolve([1, Promise.resolve(2), 3])
     ).then(actual => assert.strictEqual(actual, 6));
@@ -160,12 +161,9 @@ describe('reduceRightP', function() {
     const testCatRight = catRight(['1', '2', '3', '4']).then(actual =>
       assert.strictEqual(actual, '1234')
     );
-    const testCatRightFlipped = catRightFlipped([
-      '1',
-      '2',
-      '3',
-      '4',
-    ]).then(actual => assert.strictEqual(actual, '4321'));
+    const testCatRightFlipped = catRightFlipped(['1', '2', '3', '4']).then(
+      actual => assert.strictEqual(actual, '4321')
+    );
 
     return Promise.all([testCat, testCatRight, testCatRightFlipped]);
   });

--- a/test/rejectP.js
+++ b/test/rejectP.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('rejectP', function() {
   const rejectWithError = () =>
@@ -8,29 +9,29 @@ describe('rejectP', function() {
   it('tests rejecting with no arguments', function() {
     return RA.rejectP()
       .then(rejectWithError)
-      .catch(actual => eq(actual, undefined));
+      .catch(actual => assert.isUndefined(actual));
   });
 
   it('tests rejecting thenable values', function() {
     const expected = Promise.resolve(1);
     return RA.rejectP(expected)
       .then(rejectWithError)
-      .catch(actual => eq(actual, expected));
+      .catch(actual => assert.deepEqual(actual, expected));
   });
 
   it('tests rejecting the only argument', function() {
     const testNumber = RA.rejectP(1)
       .then(rejectWithError)
-      .catch(actual => eq(actual, 1));
+      .catch(actual => assert.strictEqual(actual, 1));
     const testString = RA.rejectP('a')
       .then(rejectWithError)
-      .catch(actual => eq(actual, 'a'));
+      .catch(actual => assert.strictEqual(actual, 'a'));
     const testArray = RA.rejectP([1, 2, 3])
       .then(rejectWithError)
-      .catch(actual => eq(actual, [1, 2, 3]));
+      .catch(actual => assert.sameOrderedMembers(actual, [1, 2, 3]));
     const testObj = RA.rejectP({ a: 1 })
       .then(rejectWithError)
-      .catch(actual => eq(actual, { a: 1 }));
+      .catch(actual => assert.deepEqual(actual, { a: 1 }));
 
     return Promise.all([testNumber, testString, testArray, testObj]);
   });

--- a/test/renameKeys.js
+++ b/test/renameKeys.js
@@ -1,31 +1,43 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('renameKeys', function() {
   it('tests renaming object keys', function() {
-    eq(RA.renameKeys({ key1: 'key2', key2: 'key3' }, { key1: 1, key2: 2 }), {
-      key2: 1,
-      key3: 2,
-    });
+    assert.deepEqual(
+      RA.renameKeys({ key1: 'key2', key2: 'key3' }, { key1: 1, key2: 2 }),
+      {
+        key2: 1,
+        key3: 2,
+      }
+    );
   });
 
   it('tests renaming non existing keys', function() {
-    eq(RA.renameKeys({ nonExistingKey: 'key2' }, { key1: 1 }), { key1: 1 });
+    assert.deepEqual(RA.renameKeys({ nonExistingKey: 'key2' }, { key1: 1 }), {
+      key1: 1,
+    });
   });
 
   it('tests renaming keys on non object', function() {
-    eq(RA.renameKeys({ key1: 'key2' }, null), {});
-    eq(RA.renameKeys({ key1: 'key2' }, undefined), {});
+    assert.deepEqual(RA.renameKeys({ key1: 'key2' }, null), {});
+    assert.deepEqual(RA.renameKeys({ key1: 'key2' }, undefined), {});
   });
 
   it('tests currying', function() {
-    eq(RA.renameKeys({ key1: 'key2', key2: 'key3' }, { key1: 1, key2: 2 }), {
-      key2: 1,
-      key3: 2,
-    });
-    eq(RA.renameKeys({ key1: 'key2', key2: 'key3' })({ key1: 1, key2: 2 }), {
-      key2: 1,
-      key3: 2,
-    });
+    assert.deepEqual(
+      RA.renameKeys({ key1: 'key2', key2: 'key3' }, { key1: 1, key2: 2 }),
+      {
+        key2: 1,
+        key3: 2,
+      }
+    );
+    assert.deepEqual(
+      RA.renameKeys({ key1: 'key2', key2: 'key3' })({ key1: 1, key2: 2 }),
+      {
+        key2: 1,
+        key3: 2,
+      }
+    );
   });
 });

--- a/test/renameKeysWith.js
+++ b/test/renameKeysWith.js
@@ -1,23 +1,23 @@
+import { assert } from 'chai';
 import { concat } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('renameKeysWith', function() {
   it('tests renaming object keys', function() {
-    eq(RA.renameKeysWith(concat('a'), { key1: 1, key2: 2 }), {
+    assert.deepEqual(RA.renameKeysWith(concat('a'), { key1: 1, key2: 2 }), {
       akey1: 1,
       akey2: 2,
     });
   });
 
   it('tests renaming keys on nil', function() {
-    eq(RA.renameKeysWith(concat('a'), null), {});
-    eq(RA.renameKeysWith(concat('a'), undefined), {});
+    assert.deepEqual(RA.renameKeysWith(concat('a'), null), {});
+    assert.deepEqual(RA.renameKeysWith(concat('a'), undefined), {});
   });
 
   it('tests currying', function() {
-    eq(RA.renameKeysWith(concat('a'))({ key1: 1, key2: 2 }), {
+    assert.deepEqual(RA.renameKeysWith(concat('a'))({ key1: 1, key2: 2 }), {
       akey1: 1,
       akey2: 2,
     });

--- a/test/repeatStr.js
+++ b/test/repeatStr.js
@@ -2,28 +2,27 @@ import { assert } from 'chai';
 
 import * as RA from '../src';
 import { repeatStrInvoker, repeatStrPolyfill } from '../src/repeatStr';
-import eq from './shared/eq';
 
 describe('repeatStr', function() {
   specify('should repeat string n times', function() {
-    eq(RA.repeatStr('abc', 3), 'abcabcabc');
+    assert.strictEqual(RA.repeatStr('abc', 3), 'abcabcabc');
   });
 
   context('given count 0', function() {
     specify('should return empty string', function() {
-      eq(RA.repeatStr('abc', 0), '');
+      assert.strictEqual(RA.repeatStr('abc', 0), '');
     });
   });
 
   context('given count 1', function() {
     specify('should return original string', function() {
-      eq(RA.repeatStr('abc', 1), 'abc');
+      assert.strictEqual(RA.repeatStr('abc', 1), 'abc');
     });
   });
 
   context('given count supplied as float', function() {
     specify('should convert count to integer', function() {
-      eq(RA.repeatStr('abc', 3.5), 'abcabcabc');
+      assert.strictEqual(RA.repeatStr('abc', 3.5), 'abcabcabc');
     });
   });
 
@@ -41,16 +40,16 @@ describe('repeatStr', function() {
 
   context('given count is not a number', function() {
     specify('should return empty string', function() {
-      eq(RA.repeatStr('abc', 'a'), '');
-      eq(RA.repeatStr('abc', null), '');
-      eq(RA.repeatStr('abc', undefined), '');
-      eq(RA.repeatStr('abc', NaN), '');
+      assert.strictEqual(RA.repeatStr('abc', 'a'), '');
+      assert.strictEqual(RA.repeatStr('abc', null), '');
+      assert.strictEqual(RA.repeatStr('abc', undefined), '');
+      assert.strictEqual(RA.repeatStr('abc', NaN), '');
     });
   });
 
   specify('should be curried', function() {
-    eq(RA.repeatStr('abc', 3.5), 'abcabcabc');
-    eq(RA.repeatStr('abc')(3.5), 'abcabcabc');
+    assert.strictEqual(RA.repeatStr('abc', 3.5), 'abcabcabc');
+    assert.strictEqual(RA.repeatStr('abc')(3.5), 'abcabcabc');
   });
 
   context('repeatStrInvoker', function() {
@@ -61,24 +60,24 @@ describe('repeatStr', function() {
     });
 
     specify('should repeat string n times', function() {
-      eq(repeatStrInvoker('abc', 3), 'abcabcabc');
+      assert.strictEqual(repeatStrInvoker('abc', 3), 'abcabcabc');
     });
 
     context('given count 0', function() {
       specify('should return empty string', function() {
-        eq(repeatStrInvoker('abc', 0), '');
+        assert.strictEqual(repeatStrInvoker('abc', 0), '');
       });
     });
 
     context('given count 1', function() {
       specify('should return original string', function() {
-        eq(repeatStrInvoker('abc', 1), 'abc');
+        assert.strictEqual(repeatStrInvoker('abc', 1), 'abc');
       });
     });
 
     context('given count supplied as float', function() {
       specify('should convert count to integer', function() {
-        eq(repeatStrInvoker('abc', 3.5), 'abcabcabc');
+        assert.strictEqual(repeatStrInvoker('abc', 3.5), 'abcabcabc');
       });
     });
 
@@ -96,39 +95,39 @@ describe('repeatStr', function() {
 
     context('given count is not a number', function() {
       specify('should return empty string', function() {
-        eq(repeatStrInvoker('abc', 'a'), '');
-        eq(repeatStrInvoker('abc', null), '');
-        eq(repeatStrInvoker('abc', undefined), '');
-        eq(repeatStrInvoker('abc', NaN), '');
+        assert.strictEqual(repeatStrInvoker('abc', 'a'), '');
+        assert.strictEqual(repeatStrInvoker('abc', null), '');
+        assert.strictEqual(repeatStrInvoker('abc', undefined), '');
+        assert.strictEqual(repeatStrInvoker('abc', NaN), '');
       });
     });
 
     specify('should be curried', function() {
-      eq(repeatStrInvoker('abc', 3.5), 'abcabcabc');
-      eq(repeatStrInvoker('abc')(3.5), 'abcabcabc');
+      assert.strictEqual(repeatStrInvoker('abc', 3.5), 'abcabcabc');
+      assert.strictEqual(repeatStrInvoker('abc')(3.5), 'abcabcabc');
     });
   });
 
   context('repeatStrPolyfill', function() {
     specify('should repeat string n times', function() {
-      eq(repeatStrPolyfill('abc', 3), 'abcabcabc');
+      assert.strictEqual(repeatStrPolyfill('abc', 3), 'abcabcabc');
     });
 
     context('given count 0', function() {
       specify('should return empty string', function() {
-        eq(repeatStrPolyfill('abc', 0), '');
+        assert.strictEqual(repeatStrPolyfill('abc', 0), '');
       });
     });
 
     context('given count 1', function() {
       specify('should return original string', function() {
-        eq(repeatStrPolyfill('abc', 1), 'abc');
+        assert.strictEqual(repeatStrPolyfill('abc', 1), 'abc');
       });
     });
 
     context('given count supplied as float', function() {
       specify('should convert count to integer', function() {
-        eq(repeatStrPolyfill('abc', 3.5), 'abcabcabc');
+        assert.strictEqual(repeatStrPolyfill('abc', 3.5), 'abcabcabc');
       });
     });
 
@@ -146,16 +145,16 @@ describe('repeatStr', function() {
 
     context('given count is not a number', function() {
       specify('should return empty string', function() {
-        eq(repeatStrPolyfill('abc', 'a'), '');
-        eq(repeatStrPolyfill('abc', null), '');
-        eq(repeatStrPolyfill('abc', undefined), '');
-        eq(repeatStrPolyfill('abc', NaN), '');
+        assert.strictEqual(repeatStrPolyfill('abc', 'a'), '');
+        assert.strictEqual(repeatStrPolyfill('abc', null), '');
+        assert.strictEqual(repeatStrPolyfill('abc', undefined), '');
+        assert.strictEqual(repeatStrPolyfill('abc', NaN), '');
       });
     });
 
     specify('should be curried', function() {
-      eq(repeatStrPolyfill('abc', 3.5), 'abcabcabc');
-      eq(repeatStrPolyfill('abc')(3.5), 'abcabcabc');
+      assert.strictEqual(repeatStrPolyfill('abc', 3.5), 'abcabcabc');
+      assert.strictEqual(repeatStrPolyfill('abc')(3.5), 'abcabcabc');
     });
   });
 });


### PR DESCRIPTION
Batch 18

test/
- reduceRightP.js
- rejectP.js
- renameKeys.js
- renameKeysWith.js
- repeatStr.js