### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#19

### DIFF
--- a/test/resolveP.js
+++ b/test/resolveP.js
@@ -1,13 +1,15 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('resolveP', function() {
   it('tests resolving with no arguments', function() {
-    return RA.resolveP().then(actual => eq(actual, undefined));
+    return RA.resolveP().then(actual => assert.isUndefined(actual));
   });
 
   it('tests resolving thenable values', function() {
-    return RA.resolveP(Promise.resolve(1)).then(actual => eq(actual, 1));
+    return RA.resolveP(Promise.resolve(1)).then(actual =>
+      assert.strictEqual(actual, 1));
   });
 
   it('tests resolving the only argument', function() {

--- a/test/resolveP.js
+++ b/test/resolveP.js
@@ -9,7 +9,8 @@ describe('resolveP', function() {
 
   it('tests resolving thenable values', function() {
     return RA.resolveP(Promise.resolve(1)).then(actual =>
-      assert.strictEqual(actual, 1));
+      assert.strictEqual(actual, 1)
+    );
   });
 
   it('tests resolving the only argument', function() {

--- a/test/round.js
+++ b/test/round.js
@@ -2,42 +2,41 @@ import * as R from 'ramda';
 import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 
 describe('round', function() {
   it('should round float to nearest integer', function() {
-    eq(RA.round(0.9), 1);
-    eq(RA.round(5.95), 6);
-    eq(RA.round(5.5), 6);
-    eq(RA.round(5.05), 5);
-    eq(RA.round(-5.05), -5);
-    eq(RA.round(-5.5), -5);
-    eq(RA.round(-5.95), -6);
+    assert.strictEqual(RA.round(0.9), 1);
+    assert.strictEqual(RA.round(5.95), 6);
+    assert.strictEqual(RA.round(5.5), 6);
+    assert.strictEqual(RA.round(5.05), 5);
+    assert.strictEqual(RA.round(-5.05), -5);
+    assert.strictEqual(RA.round(-5.5), -5);
+    assert.strictEqual(RA.round(-5.95), -6);
   });
 
   context('given integer number', function() {
     specify('should return original integer number', function() {
-      eq(RA.round(0), 0);
-      eq(RA.round(1), 1);
-      eq(RA.round(-1), -1);
+      assert.strictEqual(RA.round(0), 0);
+      assert.strictEqual(RA.round(1), 1);
+      assert.strictEqual(RA.round(-1), -1);
     });
   });
 
   context('given value that is not a number', function() {
     specify('should return NaN', function() {
-      eq(RA.round(undefined), NaN);
-      eq(RA.round(NaN), NaN);
-      eq(RA.round({}), NaN);
-      eq(RA.round(/a/), NaN);
-      eq(RA.round('test'), NaN);
-      eq(RA.round(new Error()), NaN);
+      assert.isNaN(RA.round(undefined));
+      assert.isNaN(RA.round(NaN));
+      assert.isNaN(RA.round({}));
+      assert.isNaN(RA.round(/a/));
+      assert.isNaN(RA.round('test'));
+      assert.isNaN(RA.round(new Error()));
     });
   });
 
   context('given null', function() {
     specify('should return 0', function() {
-      eq(RA.round(null), 0);
+      assert.strictEqual(RA.round(null), 0);
     });
   });
 
@@ -61,21 +60,21 @@ describe('round', function() {
     specify(
       'should return the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC',
       function() {
-        eq(RA.round(new Date(2)), 2);
+        assert.strictEqual(RA.round(new Date(2)), 2);
       }
     );
   });
 
   context('given Infinity value', function() {
     specify('should return untouched Infinity value', function() {
-      eq(RA.round(Infinity), Infinity);
-      eq(RA.round(-Infinity), -Infinity);
+      assert.strictEqual(RA.round(Infinity), Infinity);
+      assert.strictEqual(RA.round(-Infinity), -Infinity);
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const round = RA.round(R.__);
 
-    eq(round(0.9), 1);
+    assert.strictEqual(round(0.9), 1);
   });
 });

--- a/test/seq.js
+++ b/test/seq.js
@@ -1,15 +1,15 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('seq', function() {
   it('tests calling uncurried', function() {
-    eq(RA.seq([RA.noop], 3), 3);
+    assert.strictEqual(RA.seq([RA.noop], 3), 3);
   });
 
   it('tests calling curried', function() {
-    eq(RA.seq([RA.noop])(3), 3);
+    assert.strictEqual(RA.seq([RA.noop])(3), 3);
   });
 
   it('tests ordered evaluation', function() {
@@ -24,8 +24,8 @@ describe('seq', function() {
 
     const seqed = RA.seq([multiply, divide])(3);
 
-    eq(seqed, 3);
-    eq(foo, 2);
+    assert.strictEqual(seqed, 3);
+    assert.strictEqual(foo, 2);
   });
 
   it('tests transducing', function() {
@@ -41,10 +41,10 @@ describe('seq', function() {
       R.range(0, 10)
     );
 
-    eq(transduced, [2, 4, 6, 8, 10]);
+    assert.sameOrderedMembers(transduced, [2, 4, 6, 8, 10]);
   });
 
   it('tests an alias', function() {
-    eq(RA.sequencing([RA.noop])(0), 0);
+    assert.strictEqual(RA.sequencing([RA.noop])(0), 0);
   });
 });

--- a/test/sign.js
+++ b/test/sign.js
@@ -2,49 +2,48 @@ import * as R from 'ramda';
 import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import { signPolyfill } from '../src/sign';
 
 describe('sign', function() {
   it('should return proper sign result', function() {
-    eq(RA.sign(3), 1);
-    eq(RA.sign(3.3), 1);
-    eq(RA.sign(-3), -1);
-    eq(RA.sign(-3.3), -1);
-    eq(RA.sign(0), 0);
-    eq(RA.sign(-0), -0);
+    assert.strictEqual(RA.sign(3), 1);
+    assert.strictEqual(RA.sign(3.3), 1);
+    assert.strictEqual(RA.sign(-3), -1);
+    assert.strictEqual(RA.sign(-3.3), -1);
+    assert.strictEqual(RA.sign(0), 0);
+    assert.strictEqual(RA.sign(-0), -0);
   });
 
   context('given number in string', function() {
     specify('should return proper sign', function() {
-      eq(RA.sign('-1.123'), -1);
-      eq(RA.sign('1.123'), 1);
+      assert.strictEqual(RA.sign('-1.123'), -1);
+      assert.strictEqual(RA.sign('1.123'), 1);
     });
   });
 
   context('given integer number', function() {
     specify('should return original integer number', function() {
-      eq(RA.sign(0), 0);
-      eq(RA.sign(1), 1);
-      eq(RA.sign(-1), -1);
+      assert.strictEqual(RA.sign(0), 0);
+      assert.strictEqual(RA.sign(1), 1);
+      assert.strictEqual(RA.sign(-1), -1);
     });
   });
 
   context('given value that is not a number', function() {
     specify('should return NaN', function() {
-      eq(RA.sign(undefined), NaN);
-      eq(RA.sign(NaN), NaN);
-      eq(RA.sign({}), NaN);
-      eq(RA.sign(/a/), NaN);
-      eq(RA.sign('test'), NaN);
-      eq(RA.sign(new Error()), NaN);
+      assert.isNaN(RA.sign(undefined));
+      assert.isNaN(RA.sign(NaN));
+      assert.isNaN(RA.sign({}));
+      assert.isNaN(RA.sign(/a/));
+      assert.isNaN(RA.sign('test'));
+      assert.isNaN(RA.sign(new Error()));
     });
   });
 
   context('given null', function() {
     specify('should return 0', function() {
-      eq(RA.sign(null), 0);
+      assert.strictEqual(RA.sign(null), 0);
     });
   });
 
@@ -68,22 +67,22 @@ describe('sign', function() {
     specify(
       'should return the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC',
       function() {
-        eq(RA.sign(new Date(2)), 1);
+        assert.strictEqual(RA.sign(new Date(2)), 1);
       }
     );
   });
 
   context('given Infinity value', function() {
     specify('should return proper sign', function() {
-      eq(RA.sign(Infinity), 1);
-      eq(RA.sign(-Infinity), -1);
+      assert.strictEqual(RA.sign(Infinity), 1);
+      assert.strictEqual(RA.sign(-Infinity), -1);
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const sign = RA.sign(R.__);
 
-    eq(sign(0.9), 1);
+    assert.strictEqual(sign(0.9), 1);
   });
 
   context('signPolyfill', function() {
@@ -94,43 +93,43 @@ describe('sign', function() {
     });
 
     specify('should return proper sign result', function() {
-      eq(signPolyfill(3), 1);
-      eq(signPolyfill(3.3), 1);
-      eq(signPolyfill(-3), -1);
-      eq(signPolyfill(-3.3), -1);
-      eq(signPolyfill(0), 0);
-      eq(signPolyfill(-0), -0);
+      assert.strictEqual(signPolyfill(3), 1);
+      assert.strictEqual(signPolyfill(3.3), 1);
+      assert.strictEqual(signPolyfill(-3), -1);
+      assert.strictEqual(signPolyfill(-3.3), -1);
+      assert.strictEqual(signPolyfill(0), 0);
+      assert.strictEqual(signPolyfill(-0), -0);
     });
 
     context('given number in string', function() {
       specify('should return proper sign', function() {
-        eq(signPolyfill('-1.123'), -1);
-        eq(signPolyfill('1.123'), 1);
+        assert.strictEqual(signPolyfill('-1.123'), -1);
+        assert.strictEqual(signPolyfill('1.123'), 1);
       });
     });
 
     context('given integer number', function() {
       specify('should return original integer number', function() {
-        eq(signPolyfill(0), 0);
-        eq(signPolyfill(1), 1);
-        eq(signPolyfill(-1), -1);
+        assert.strictEqual(signPolyfill(0), 0);
+        assert.strictEqual(signPolyfill(1), 1);
+        assert.strictEqual(signPolyfill(-1), -1);
       });
     });
 
     context('given value that is not a number', function() {
       specify('should return NaN', function() {
-        eq(signPolyfill(undefined), NaN);
-        eq(signPolyfill(NaN), NaN);
-        eq(signPolyfill({}), NaN);
-        eq(signPolyfill(/a/), NaN);
-        eq(signPolyfill('test'), NaN);
-        eq(signPolyfill(new Error()), NaN);
+        assert.isNaN(signPolyfill(undefined));
+        assert.isNaN(signPolyfill(NaN));
+        assert.isNaN(signPolyfill({}));
+        assert.isNaN(signPolyfill(/a/));
+        assert.isNaN(signPolyfill('test'));
+        assert.isNaN(signPolyfill(new Error()));
       });
     });
 
     context('given null', function() {
       specify('should return 0', function() {
-        eq(signPolyfill(null), 0);
+        assert.strictEqual(signPolyfill(null), 0);
       });
     });
 
@@ -154,22 +153,22 @@ describe('sign', function() {
       specify(
         'should return the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC',
         function() {
-          eq(signPolyfill(new Date(2)), 1);
+          assert.strictEqual(signPolyfill(new Date(2)), 1);
         }
       );
     });
 
     context('given Infinity value', function() {
       specify('should return proper sign', function() {
-        eq(signPolyfill(Infinity), 1);
-        eq(signPolyfill(-Infinity), -1);
+        assert.strictEqual(signPolyfill(Infinity), 1);
+        assert.strictEqual(signPolyfill(-Infinity), -1);
       });
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const sign = RA.sign(R.__);
 
-      eq(sign(0.9), 1);
+      assert.strictEqual(sign(0.9), 1);
     });
   });
 });

--- a/test/sliceFrom.js
+++ b/test/sliceFrom.js
@@ -1,28 +1,29 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('sliceFrom', function() {
   it('retrieves the proper sublist of a list', function() {
     const list = [8, 6, 7, 5, 3, 0, 9];
-    eq(RA.sliceFrom(2, list), [7, 5, 3, 0, 9]);
+    assert.sameOrderedMembers(RA.sliceFrom(2, list), [7, 5, 3, 0, 9]);
   });
 
   it('handles array-like object', function() {
     const args = (function() {
       return arguments;
     })(1, 2, 3, 4, 5);
-    eq(RA.sliceFrom(1, args), [2, 3, 4, 5]);
+    assert.sameOrderedMembers(RA.sliceFrom(1, args), [2, 3, 4, 5]);
   });
 
   it('can operate on strings', function() {
-    eq(RA.sliceFrom(0, 'abc'), 'abc');
-    eq(RA.sliceFrom(1, 'abc'), 'bc');
-    eq(RA.sliceFrom(2, 'abc'), 'c');
-    eq(RA.sliceFrom(3, 'abc'), '');
-    eq(RA.sliceFrom(4, 'abc'), '');
-    eq(RA.sliceFrom(-4, 'abc'), 'abc');
-    eq(RA.sliceFrom(-3, 'abc'), 'abc');
-    eq(RA.sliceFrom(-2, 'abc'), 'bc');
-    eq(RA.sliceFrom(-1, 'abc'), 'c');
+    assert.strictEqual(RA.sliceFrom(0, 'abc'), 'abc');
+    assert.strictEqual(RA.sliceFrom(1, 'abc'), 'bc');
+    assert.strictEqual(RA.sliceFrom(2, 'abc'), 'c');
+    assert.strictEqual(RA.sliceFrom(3, 'abc'), '');
+    assert.strictEqual(RA.sliceFrom(4, 'abc'), '');
+    assert.strictEqual(RA.sliceFrom(-4, 'abc'), 'abc');
+    assert.strictEqual(RA.sliceFrom(-3, 'abc'), 'abc');
+    assert.strictEqual(RA.sliceFrom(-2, 'abc'), 'bc');
+    assert.strictEqual(RA.sliceFrom(-1, 'abc'), 'c');
   });
 });


### PR DESCRIPTION
Batch 19

test/
- resolveP.js
- round.js
- seq.js
- sign.js
- sliceFrom.js
