### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#20

### DIFF
--- a/test/sliceTo.js
+++ b/test/sliceTo.js
@@ -1,28 +1,29 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('sliceTo', function() {
   it('retrieves the proper sublist of a list', function() {
     const list = [8, 6, 7, 5, 3, 0, 9];
-    eq(RA.sliceTo(3, list), [8, 6, 7]);
+    assert.sameOrderedMembers(RA.sliceTo(3, list), [8, 6, 7]);
   });
 
   it('handles array-like object', function() {
     const args = (function() {
       return arguments;
     })(1, 2, 3, 4, 5);
-    eq(RA.sliceTo(2, args), [1, 2]);
+    assert.sameOrderedMembers(RA.sliceTo(2, args), [1, 2]);
   });
 
   it('can operate on strings', function() {
-    eq(RA.sliceTo(0, 'abc'), '');
-    eq(RA.sliceTo(1, 'abc'), 'a');
-    eq(RA.sliceTo(2, 'abc'), 'ab');
-    eq(RA.sliceTo(3, 'abc'), 'abc');
-    eq(RA.sliceTo(4, 'abc'), 'abc');
-    eq(RA.sliceTo(-4, 'abc'), '');
-    eq(RA.sliceTo(-3, 'abc'), '');
-    eq(RA.sliceTo(-2, 'abc'), 'a');
-    eq(RA.sliceTo(-1, 'abc'), 'ab');
+    assert.strictEqual(RA.sliceTo(0, 'abc'), '');
+    assert.strictEqual(RA.sliceTo(1, 'abc'), 'a');
+    assert.strictEqual(RA.sliceTo(2, 'abc'), 'ab');
+    assert.strictEqual(RA.sliceTo(3, 'abc'), 'abc');
+    assert.strictEqual(RA.sliceTo(4, 'abc'), 'abc');
+    assert.strictEqual(RA.sliceTo(-4, 'abc'), '');
+    assert.strictEqual(RA.sliceTo(-3, 'abc'), '');
+    assert.strictEqual(RA.sliceTo(-2, 'abc'), 'a');
+    assert.strictEqual(RA.sliceTo(-1, 'abc'), 'ab');
   });
 });

--- a/test/spreadPath.js
+++ b/test/spreadPath.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('spreadPath', function() {
   let path;
@@ -16,8 +17,8 @@ describe('spreadPath', function() {
   it('tests currying', function() {
     const expected = { a: 1, c: 3, d: 4, b1: {} };
 
-    eq(RA.spreadPath(path, obj), expected);
-    eq(RA.spreadPath(path)(obj), expected);
+    assert.deepEqual(RA.spreadPath(path, obj), expected);
+    assert.deepEqual(RA.spreadPath(path)(obj), expected);
   });
 
   context('given path leads to non object', function() {
@@ -26,7 +27,7 @@ describe('spreadPath', function() {
         a: 1,
         b1: { b2: 999 },
       };
-      eq(RA.spreadPath(path, obj), { a: 1, b1: {} });
+      assert.deepEqual(RA.spreadPath(path, obj), { a: 1, b1: {} });
     });
   });
 
@@ -34,7 +35,7 @@ describe('spreadPath', function() {
     specify(
       'should return object with identical structure as provided object',
       function() {
-        eq(RA.spreadPath(['does', 'not', 'exist'], obj), obj);
+        assert.deepEqual(RA.spreadPath(['does', 'not', 'exist'], obj), obj);
       }
     );
   });

--- a/test/spreadProp.js
+++ b/test/spreadProp.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('spreadProp', function() {
   let prop;
@@ -14,15 +15,15 @@ describe('spreadProp', function() {
   });
 
   it('tests currying', function() {
-    eq(RA.spreadProp('prop', {}), {});
-    eq(RA.spreadProp('prop')({}), {});
+    assert.deepEqual(RA.spreadProp('prop', {}), {});
+    assert.deepEqual(RA.spreadProp('prop')({}), {});
   });
 
   context("given prop doesn't exist", function() {
     specify(
       'should return object with identical structure as provided object',
       function() {
-        eq(RA.spreadProp('not_exist', obj), obj);
+        assert.deepEqual(RA.spreadProp('not_exist', obj), obj);
       }
     );
   });
@@ -34,7 +35,7 @@ describe('spreadProp', function() {
         b: 999,
       };
 
-      eq(RA.spreadProp(prop, obj), { a: 1 });
+      assert.deepEqual(RA.spreadProp(prop, obj), { a: 1 });
     });
   });
 
@@ -51,7 +52,7 @@ describe('spreadProp', function() {
         b: 999,
       };
 
-      eq(RA.spreadProp(prop, obj), expected);
+      assert.deepEqual(RA.spreadProp(prop, obj), expected);
     });
   });
 
@@ -62,6 +63,6 @@ describe('spreadProp', function() {
       d: 4,
     };
 
-    eq(RA.spreadProp(prop, obj), expected);
+    assert.deepEqual(RA.spreadProp(prop, obj), expected);
   });
 });

--- a/test/stubArray.js
+++ b/test/stubArray.js
@@ -1,14 +1,13 @@
-import assert from 'assert';
+import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('stubArray', function() {
   it('tests `function` that returns empty array', function() {
-    eq(RA.stubArray(), []);
-    eq(RA.stubArray([1]), []);
-    eq(RA.stubArray(new Array()), []);
-    eq(RA.stubArray(1, 2, 3), []);
+    assert.sameOrderedMembers(RA.stubArray(), []);
+    assert.sameOrderedMembers(RA.stubArray([1]), []);
+    assert.sameOrderedMembers(RA.stubArray(new Array()), []);
+    assert.sameOrderedMembers(RA.stubArray(1, 2, 3), []);
   });
 
   context('when called', function() {

--- a/test/stubNull.js
+++ b/test/stubNull.js
@@ -1,11 +1,12 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('stubNull', function() {
   it('tests `function` that returns `null`', function() {
-    eq(RA.stubNull(), null);
-    eq(RA.stubNull([1]), null);
-    eq(RA.stubNull(new Array()), null);
-    eq(RA.stubNull(1, 2, 3), null);
+    assert.isNull(RA.stubNull());
+    assert.isNull(RA.stubNull([1]));
+    assert.isNull(RA.stubNull(new Array()));
+    assert.isNull(RA.stubNull(1, 2, 3));
   });
 });

--- a/test/stubObj.js
+++ b/test/stubObj.js
@@ -1,14 +1,13 @@
-import assert from 'assert';
+import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('stubObj', function() {
   it('tests `function` that returns new empty object', function() {
-    eq(RA.stubObj(), {});
-    eq(RA.stubObj([1]), {});
-    eq(RA.stubObj(new Array()), {});
-    eq(RA.stubObj(1, 2, 3), {});
+    assert.deepEqual(RA.stubObj(), {});
+    assert.deepEqual(RA.stubObj([1]), {});
+    assert.deepEqual(RA.stubObj(new Array()), {});
+    assert.deepEqual(RA.stubObj(1, 2, 3), {});
   });
 
   context('when called', function() {

--- a/test/stubString.js
+++ b/test/stubString.js
@@ -1,19 +1,20 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('stubString', function() {
   it("tests `function` that returns `'''`", function() {
-    eq(RA.stubString(), '');
-    eq(RA.stubString([1]), '');
-    eq(RA.stubString(new Array()), '');
-    eq(RA.stubString(1, 2, 3), '');
+    assert.strictEqual(RA.stubString(), '');
+    assert.strictEqual(RA.stubString([1]), '');
+    assert.strictEqual(RA.stubString(new Array()), '');
+    assert.strictEqual(RA.stubString(1, 2, 3), '');
   });
 
   context('when called', function() {
     specify('should always return empty string', function() {
       const ret1 = RA.stubString();
       const ret2 = RA.stubString();
-      eq(ret1, ret2);
+      assert.strictEqual(ret1, ret2);
     });
   });
 });


### PR DESCRIPTION
Batch 20
test/
- sliceTo.js
- spreadPath.js
- spreadProp.js
- stubArray.js
- stubNull.js
- stubObj.js
- stubString.js
