### PR TITLE
test(files): Use chai directly instead of internal eq function in test asserts, B#21

### DIFF
--- a/test/Y.js
+++ b/test/Y.js
@@ -1,5 +1,6 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('Y', function() {
   it('tests for making a factorial function', function() {
@@ -12,6 +13,6 @@ describe('Y', function() {
 
     const factorial = RA.Y(makeFact);
 
-    eq(factorial(5), 120);
+    assert.strictEqual(factorial(5), 120);
   });
 });

--- a/test/stubUndefined.js
+++ b/test/stubUndefined.js
@@ -1,11 +1,12 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('stubUndefined', function() {
   it('tests `function` that returns `undefined`', function() {
-    eq(RA.stubUndefined(), undefined);
-    eq(RA.stubUndefined([1]), undefined);
-    eq(RA.stubUndefined(new Array()), undefined);
-    eq(RA.stubUndefined(1, 2, 3), undefined);
+    assert.isUndefined(RA.stubUndefined());
+    assert.isUndefined(RA.stubUndefined([1]));
+    assert.isUndefined(RA.stubUndefined(new Array()));
+    assert.isUndefined(RA.stubUndefined(1, 2, 3));
   });
 });

--- a/test/subtractNum.js
+++ b/test/subtractNum.js
@@ -1,15 +1,16 @@
+import { assert } from 'chai';
+
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('subtractNum', function() {
   it('should subtract the first number from the second number', function() {
-    eq(RA.subtractNum(3, 5), 2);
-    eq(RA.subtractNum(5, 3), -2);
-    eq(RA.subtractNum(3, 'foo'), NaN);
+    assert.strictEqual(RA.subtractNum(3, 5), 2);
+    assert.strictEqual(RA.subtractNum(5, 3), -2);
+    assert.isNaN(RA.subtractNum(3, 'foo'));
   });
 
   it('should curry', function() {
-    eq(RA.subtractNum(3)(5), 2);
-    eq(RA.subtractNum(3, 5), 2);
+    assert.strictEqual(RA.subtractNum(3)(5), 2);
+    assert.strictEqual(RA.subtractNum(3, 5), 2);
   });
 });

--- a/test/trimEnd.js
+++ b/test/trimEnd.js
@@ -1,37 +1,37 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
 import { trimEndInvoker, trimEndPolyfill } from '../src/trimEnd';
-import eq from './shared/eq';
 
 describe('trimEnd', function() {
   specify('should remove whitespace from the end of a string', function() {
-    eq(RA.trimEnd('abc   '), 'abc');
+    assert.strictEqual(RA.trimEnd('abc   '), 'abc');
   });
 
   specify(
     'should not remove whitespace from the rest of the string',
     function() {
-      eq(RA.trimEnd(' a b c'), ' a b c');
+      assert.strictEqual(RA.trimEnd(' a b c'), ' a b c');
     }
   );
 
   context('given an empty string', function() {
     specify('should return an empty string', function() {
-      eq(RA.trimEnd(''), '');
+      assert.strictEqual(RA.trimEnd(''), '');
     });
   });
 
   context('given an string with whitespaces only', function() {
     specify('should return an empty string', function() {
-      eq(RA.trimEnd('   '), '');
+      assert.strictEqual(RA.trimEnd('   '), '');
     });
   });
 
   specify('should support placeholder to specify "gaps"', function() {
     const trimEnd = RA.trimEnd(R.__);
 
-    eq(trimEnd('abc   '), 'abc');
+    assert.strictEqual(trimEnd('abc   '), 'abc');
   });
 
   context('trimEndInvoker', function() {
@@ -42,69 +42,69 @@ describe('trimEnd', function() {
     });
 
     specify('should remove whitespace from the end of a string', function() {
-      eq(trimEndInvoker('abc   '), 'abc');
+      assert.strictEqual(trimEndInvoker('abc   '), 'abc');
     });
 
     specify(
       'should not remove whitespace from the rest of the string',
       function() {
-        eq(trimEndInvoker(' a b c'), ' a b c');
+        assert.strictEqual(trimEndInvoker(' a b c'), ' a b c');
       }
     );
 
     context('given an empty string', function() {
       specify('should return an empty string', function() {
-        eq(trimEndInvoker(''), '');
+        assert.strictEqual(trimEndInvoker(''), '');
       });
     });
 
     context('given an string with whitespaces only', function() {
       specify('should return an empty string', function() {
-        eq(trimEndInvoker('   '), '');
+        assert.strictEqual(trimEndInvoker('   '), '');
       });
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const trimEnd = trimEndInvoker(R.__);
 
-      eq(trimEnd('abc   '), 'abc');
+      assert.strictEqual(trimEnd('abc   '), 'abc');
     });
   });
 
   context('trimEndPolyfill', function() {
     specify('should remove whitespace from the end of a string', function() {
-      eq(trimEndPolyfill('abc   '), 'abc');
+      assert.strictEqual(trimEndPolyfill('abc   '), 'abc');
     });
 
     specify(
       'should not remove whitespace from the rest of the string',
       function() {
-        eq(trimEndPolyfill(' a b c'), ' a b c');
+        assert.strictEqual(trimEndPolyfill(' a b c'), ' a b c');
       }
     );
 
     context('given an empty string', function() {
       specify('should return an empty string', function() {
-        eq(trimEndPolyfill(''), '');
+        assert.strictEqual(trimEndPolyfill(''), '');
       });
     });
 
     context('given an string with whitespaces only', function() {
       specify('should return an empty string', function() {
-        eq(trimEndPolyfill('   '), '');
+        assert.strictEqual(trimEndPolyfill('   '), '');
       });
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const trimEnd = trimEndPolyfill(R.__);
 
-      eq(trimEnd('abc   '), 'abc');
+      assert.strictEqual(trimEnd('abc   '), 'abc');
     });
   });
 });
 
 describe('trimRight', function() {
   it('should be alias of trimEnd', function() {
-    eq(RA.trimRight === RA.trimEnd, true);
+    assert.strictEqual(RA.trimRight, RA.trimEnd);
   });
 });

--- a/test/trimStart.js
+++ b/test/trimStart.js
@@ -1,40 +1,40 @@
+import { assert } from 'chai';
 import * as R from 'ramda';
 
 import * as RA from '../src';
 import { trimStartInvoker, trimStartPolyfill } from '../src/trimStart';
-import eq from './shared/eq';
 
 describe('trimStart', function() {
   specify(
     'should remove whitespace from the beginning of a string',
     function() {
-      eq(RA.trimStart('  abc'), 'abc');
+      assert.strictEqual(RA.trimStart('  abc'), 'abc');
     }
   );
 
   specify(
     'should not remove whitespace from the rest of the string',
     function() {
-      eq(RA.trimStart('a b c '), 'a b c ');
+      assert.strictEqual(RA.trimStart('a b c '), 'a b c ');
     }
   );
 
   context('given an empty string', function() {
     specify('should return an empty string', function() {
-      eq(RA.trimStart(''), '');
+      assert.strictEqual(RA.trimStart(''), '');
     });
   });
 
   context('given an string with whitespaces only', function() {
     specify('should return an empty string', function() {
-      eq(RA.trimStart('   '), '');
+      assert.strictEqual(RA.trimStart('   '), '');
     });
   });
 
   specify('should support placeholder to specify "gaps"', function() {
     const trimStart = RA.trimStart(R.__);
 
-    eq(trimStart('  abc'), 'abc');
+    assert.strictEqual(trimStart('  abc'), 'abc');
   });
 
   context('trimStartInvoker', function() {
@@ -47,33 +47,33 @@ describe('trimStart', function() {
     specify(
       'should remove whitespace from the beginning of a string',
       function() {
-        eq(trimStartInvoker('  abc'), 'abc');
+        assert.strictEqual(trimStartInvoker('  abc'), 'abc');
       }
     );
 
     specify(
       'should not remove whitespace from the rest of the string',
       function() {
-        eq(trimStartInvoker('a b c '), 'a b c ');
+        assert.strictEqual(trimStartInvoker('a b c '), 'a b c ');
       }
     );
 
     context('given an empty string', function() {
       specify('should return an empty string', function() {
-        eq(trimStartInvoker(''), '');
+        assert.strictEqual(trimStartInvoker(''), '');
       });
     });
 
     context('given an string with whitespaces only', function() {
       specify('should return an empty string', function() {
-        eq(trimStartInvoker('   '), '');
+        assert.strictEqual(trimStartInvoker('   '), '');
       });
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const trimStart = trimStartInvoker(R.__);
 
-      eq(trimStart('  abc'), 'abc');
+      assert.strictEqual(trimStart('  abc'), 'abc');
     });
   });
 
@@ -81,39 +81,39 @@ describe('trimStart', function() {
     specify(
       'should remove whitespace from the beginning of a string',
       function() {
-        eq(trimStartPolyfill('  abc'), 'abc');
+        assert.strictEqual(trimStartPolyfill('  abc'), 'abc');
       }
     );
 
     specify(
       'should not remove whitespace from the rest of the string',
       function() {
-        eq(trimStartPolyfill('a b c '), 'a b c ');
+        assert.strictEqual(trimStartPolyfill('a b c '), 'a b c ');
       }
     );
 
     context('given an empty string', function() {
       specify('should return an empty string', function() {
-        eq(trimStartPolyfill(''), '');
+        assert.strictEqual(trimStartPolyfill(''), '');
       });
     });
 
     context('given an string with whitespaces only', function() {
       specify('should return an empty string', function() {
-        eq(trimStartPolyfill('   '), '');
+        assert.strictEqual(trimStartPolyfill('   '), '');
       });
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const trimStart = trimStartPolyfill(R.__);
 
-      eq(trimStart('  abc'), 'abc');
+      assert.strictEqual(trimStart('  abc'), 'abc');
     });
   });
 });
 
 describe('trimLeft', function() {
   it('should be alias of trimStart', function() {
-    eq(RA.trimLeft === RA.trimStart, true);
+    assert.strictEqual(RA.trimLeft, RA.trimStart);
   });
 });

--- a/test/trunc.js
+++ b/test/trunc.js
@@ -2,46 +2,45 @@ import * as R from 'ramda';
 import { assert } from 'chai';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 import Symbol from './shared/Symbol';
 import { truncPolyfill } from '../src/trunc';
 
 describe('trunc', function() {
   it('should truncate fractional digits', function() {
-    eq(RA.trunc(13.37), 13);
-    eq(RA.trunc(42.84), 42);
-    eq(RA.trunc(0.123), 0);
-    eq(RA.trunc(-0.123), -0);
+    assert.strictEqual(RA.trunc(13.37), 13);
+    assert.strictEqual(RA.trunc(42.84), 42);
+    assert.strictEqual(RA.trunc(0.123), 0);
+    assert.strictEqual(RA.trunc(-0.123), -0);
   });
 
   context('given number in string', function() {
     specify('should truncate fractional digits', function() {
-      eq(RA.trunc('-1.123'), -1);
+      assert.strictEqual(RA.trunc('-1.123'), -1);
     });
   });
 
   context('given integer number', function() {
     specify('should return original integer number', function() {
-      eq(RA.trunc(0), 0);
-      eq(RA.trunc(1), 1);
-      eq(RA.trunc(-1), -1);
+      assert.strictEqual(RA.trunc(0), 0);
+      assert.strictEqual(RA.trunc(1), 1);
+      assert.strictEqual(RA.trunc(-1), -1);
     });
   });
 
   context('given value that is not a number', function() {
     specify('should return NaN', function() {
-      eq(RA.trunc(undefined), NaN);
-      eq(RA.trunc(NaN), NaN);
-      eq(RA.trunc({}), NaN);
-      eq(RA.trunc(/a/), NaN);
-      eq(RA.trunc('test'), NaN);
-      eq(RA.trunc(new Error()), NaN);
+      assert.isNaN(RA.trunc(undefined));
+      assert.isNaN(RA.trunc(NaN));
+      assert.isNaN(RA.trunc({}));
+      assert.isNaN(RA.trunc(/a/));
+      assert.isNaN(RA.trunc('test'));
+      assert.isNaN(RA.trunc(new Error()));
     });
   });
 
   context('given null', function() {
     specify('should return 0', function() {
-      eq(RA.trunc(null), 0);
+      assert.strictEqual(RA.trunc(null), 0);
     });
   });
 
@@ -65,22 +64,22 @@ describe('trunc', function() {
     specify(
       'should return the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC',
       function() {
-        eq(RA.trunc(new Date(2)), 2);
+        assert.strictEqual(RA.trunc(new Date(2)), 2);
       }
     );
   });
 
   context('given Infinity value', function() {
     specify('should return untouched Infinity value', function() {
-      eq(RA.trunc(Infinity), Infinity);
-      eq(RA.trunc(-Infinity), -Infinity);
+      assert.strictEqual(RA.trunc(Infinity), Infinity);
+      assert.strictEqual(RA.trunc(-Infinity), -Infinity);
     });
   });
 
   it('should support placeholder to specify "gaps"', function() {
     const trunc = RA.trunc(R.__);
 
-    eq(trunc(0.9), 0);
+    assert.strictEqual(trunc(0.9), 0);
   });
 
   context('truncPolyfill', function() {
@@ -91,40 +90,40 @@ describe('trunc', function() {
     });
 
     specify('should truncate fractional digits', function() {
-      eq(truncPolyfill(13.37), 13);
-      eq(truncPolyfill(42.84), 42);
-      eq(truncPolyfill(0.123), 0);
-      eq(truncPolyfill(-0.123), -0);
+      assert.strictEqual(truncPolyfill(13.37), 13);
+      assert.strictEqual(truncPolyfill(42.84), 42);
+      assert.strictEqual(truncPolyfill(0.123), 0);
+      assert.strictEqual(truncPolyfill(-0.123), -0);
     });
 
     context('given number in string', function() {
       specify('should truncate fractional digits', function() {
-        eq(truncPolyfill('-1.123'), -1);
+        assert.strictEqual(truncPolyfill('-1.123'), -1);
       });
     });
 
     context('given integer number', function() {
       specify('should return original integer number', function() {
-        eq(truncPolyfill(0), 0);
-        eq(truncPolyfill(1), 1);
-        eq(truncPolyfill(-1), -1);
+        assert.strictEqual(truncPolyfill(0), 0);
+        assert.strictEqual(truncPolyfill(1), 1);
+        assert.strictEqual(truncPolyfill(-1), -1);
       });
     });
 
     context('given value that is not a number', function() {
       specify('should return NaN', function() {
-        eq(truncPolyfill(undefined), NaN);
-        eq(truncPolyfill(NaN), NaN);
-        eq(truncPolyfill({}), NaN);
-        eq(truncPolyfill(/a/), NaN);
-        eq(truncPolyfill('test'), NaN);
-        eq(truncPolyfill(new Error()), NaN);
+        assert.isNaN(truncPolyfill(undefined));
+        assert.isNaN(truncPolyfill(NaN));
+        assert.isNaN(truncPolyfill({}));
+        assert.isNaN(truncPolyfill(/a/));
+        assert.isNaN(truncPolyfill('test'));
+        assert.isNaN(truncPolyfill(new Error()));
       });
     });
 
     context('given null', function() {
       specify('should return 0', function() {
-        eq(truncPolyfill(null), 0);
+        assert.strictEqual(truncPolyfill(null), 0);
       });
     });
 
@@ -148,22 +147,22 @@ describe('trunc', function() {
       specify(
         'should return the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC',
         function() {
-          eq(truncPolyfill(new Date(2)), 2);
+          assert.strictEqual(truncPolyfill(new Date(2)), 2);
         }
       );
     });
 
     context('given Infinity value', function() {
       specify('should return untouched Infinity value', function() {
-        eq(truncPolyfill(Infinity), Infinity);
-        eq(truncPolyfill(-Infinity), -Infinity);
+        assert.strictEqual(truncPolyfill(Infinity), Infinity);
+        assert.strictEqual(truncPolyfill(-Infinity), -Infinity);
       });
     });
 
     specify('should support placeholder to specify "gaps"', function() {
       const trunc = truncPolyfill(R.__);
 
-      eq(trunc(0.9), 0);
+      assert.strictEqual(trunc(0.9), 0);
     });
   });
 });

--- a/test/viewOr.js
+++ b/test/viewOr.js
@@ -1,30 +1,36 @@
+import { assert } from 'chai';
 import { lensIndex, lensProp } from 'ramda';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('viewOr', function() {
   it('tests "view"', function() {
-    eq(RA.viewOr('foo', lensProp('bar'), { bar: 'foobar' }), 'foobar');
-    eq(RA.viewOr('foo', lensProp('bar'), { bar: false }), false);
-    eq(RA.viewOr('foo', lensProp('bar'), { bar: 1 }), 1);
+    assert.strictEqual(
+      RA.viewOr('foo', lensProp('bar'), { bar: 'foobar' }),
+      'foobar'
+    );
+    assert.isFalse(RA.viewOr('foo', lensProp('bar'), { bar: false }));
+    assert.strictEqual(RA.viewOr('foo', lensProp('bar'), { bar: 1 }), 1);
   });
 
   it('tests found "view" with default value fallback', function() {
-    eq(RA.viewOr('foo', lensProp('bar'), { bar: undefined }), 'foo');
-    eq(RA.viewOr('foo', lensProp('bar'), { bar: null }), 'foo');
-    eq(RA.viewOr('foo', lensProp('bar'), { bar: NaN }), 'foo');
+    assert.strictEqual(
+      RA.viewOr('foo', lensProp('bar'), { bar: undefined }),
+      'foo'
+    );
+    assert.strictEqual(RA.viewOr('foo', lensProp('bar'), { bar: null }), 'foo');
+    assert.strictEqual(RA.viewOr('foo', lensProp('bar'), { bar: NaN }), 'foo');
   });
 
   it('tests default value', function() {
-    eq(RA.viewOr('foo', lensProp('bar'), {}), 'foo');
-    eq(RA.viewOr('foo', lensIndex(11), []), 'foo');
-    eq(RA.viewOr('foo', lensIndex(11), {}), 'foo');
+    assert.strictEqual(RA.viewOr('foo', lensProp('bar'), {}), 'foo');
+    assert.strictEqual(RA.viewOr('foo', lensIndex(11), []), 'foo');
+    assert.strictEqual(RA.viewOr('foo', lensIndex(11), {}), 'foo');
   });
 
   it('tests currying', function() {
-    eq(RA.viewOr('foo')(lensProp('bar'))({}), 'foo');
-    eq(RA.viewOr('foo', lensProp('bar'))({}), 'foo');
-    eq(RA.viewOr('foo')(lensProp('bar'), {}), 'foo');
+    assert.strictEqual(RA.viewOr('foo')(lensProp('bar'))({}), 'foo');
+    assert.strictEqual(RA.viewOr('foo', lensProp('bar'))({}), 'foo');
+    assert.strictEqual(RA.viewOr('foo')(lensProp('bar'), {}), 'foo');
   });
 });

--- a/test/weave.js
+++ b/test/weave.js
@@ -1,8 +1,8 @@
+import { assert } from 'chai';
 import { sum, curry } from 'ramda';
 import { Reader as reader } from 'monet';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('weave', function() {
   const unaryReader = a => reader(config => config + a);
@@ -15,55 +15,55 @@ describe('weave', function() {
     const wunaryReader = RA.weave(unaryReader, 1);
     const wbinaryReader = RA.weave(binaryReader, 1);
 
-    eq(wunaryReader(1), 2);
-    eq(wbinaryReader(2, 3), 6);
+    assert.strictEqual(wunaryReader(1), 2);
+    assert.strictEqual(wbinaryReader(2, 3), 6);
   });
 
   it('tests currying', function() {
     const wbinaryReader1 = RA.weave(binaryReader, 1);
     const wbinaryReader2 = RA.weave(binaryReader)(1);
 
-    eq(wbinaryReader1(2, 3), 6);
-    eq(wbinaryReader2(2, 3), 6);
+    assert.strictEqual(wbinaryReader1(2, 3), 6);
+    assert.strictEqual(wbinaryReader2(2, 3), 6);
   });
 
   it('tests auto-currying on fixed function signature', function() {
     const wbinaryReader = RA.weave(binaryReader, 1);
 
-    eq(wbinaryReader(2, 3), 6);
-    eq(wbinaryReader(2)(3), 6);
+    assert.strictEqual(wbinaryReader(2, 3), 6);
+    assert.strictEqual(wbinaryReader(2)(3), 6);
   });
 
   it('tests auto-currying on curried fixed function signature', function() {
     const wbinaryReader = RA.weave(curry(binaryReader), 1);
 
-    eq(wbinaryReader(2, 3), 6);
-    eq(wbinaryReader(2)(3), 6);
+    assert.strictEqual(wbinaryReader(2, 3), 6);
+    assert.strictEqual(wbinaryReader(2)(3), 6);
   });
 
   it('tests auto-currying on variadic function signature', function() {
     const wvariadicReader = RA.weave(variadicReader, 1);
 
-    eq(wvariadicReader(1, 2, 3), 7);
+    assert.strictEqual(wvariadicReader(1, 2, 3), 7);
   });
 
   it('tests auto-currying on curried variadic function signature', function() {
     const wvariadicReader = RA.weave(curry(variadicReader), 1);
 
-    eq(wvariadicReader(1, 2, 3), 7);
+    assert.strictEqual(wvariadicReader(1, 2, 3), 7);
   });
 
   it('tests auto-currying on mixed function signature', function() {
     const wmixedReader = RA.weave(mixedReader, 1);
 
-    eq(wmixedReader(2, 3, 4), 10);
-    eq(wmixedReader(2)(3, 4), 10);
+    assert.strictEqual(wmixedReader(2, 3, 4), 10);
+    assert.strictEqual(wmixedReader(2)(3, 4), 10);
   });
 
   it('tests auto-currying on curried mixed function signature', function() {
     const wmixedReader = RA.weave(curry(mixedReader), 1);
 
-    eq(wmixedReader(2, 3, 4), 10);
-    eq(wmixedReader(2)(3, 4), 10);
+    assert.strictEqual(wmixedReader(2, 3, 4), 10);
+    assert.strictEqual(wmixedReader(2)(3, 4), 10);
   });
 });

--- a/test/weaveLazy.js
+++ b/test/weaveLazy.js
@@ -1,8 +1,8 @@
+import { assert } from 'chai';
 import { sum, curry, always } from 'ramda';
 import { Reader as reader } from 'monet';
 
 import * as RA from '../src';
-import eq from './shared/eq';
 
 describe('weaveLazy', function() {
   const unaryReader = a => reader(config => config + a);
@@ -15,55 +15,55 @@ describe('weaveLazy', function() {
     const wunaryReader = RA.weaveLazy(unaryReader, always(1));
     const wbinaryReader = RA.weaveLazy(binaryReader, always(1));
 
-    eq(wunaryReader(1), 2);
-    eq(wbinaryReader(2, 3), 6);
+    assert.strictEqual(wunaryReader(1), 2);
+    assert.strictEqual(wbinaryReader(2, 3), 6);
   });
 
   it('tests currying', function() {
     const wbinaryReader1 = RA.weaveLazy(binaryReader, always(1));
     const wbinaryReader2 = RA.weaveLazy(binaryReader)(always(1));
 
-    eq(wbinaryReader1(2, 3), 6);
-    eq(wbinaryReader2(2, 3), 6);
+    assert.strictEqual(wbinaryReader1(2, 3), 6);
+    assert.strictEqual(wbinaryReader2(2, 3), 6);
   });
 
   it('tests auto-currying on fixed function signature', function() {
     const wbinaryReader = RA.weaveLazy(binaryReader, always(1));
 
-    eq(wbinaryReader(2, 3), 6);
-    eq(wbinaryReader(2)(3), 6);
+    assert.strictEqual(wbinaryReader(2, 3), 6);
+    assert.strictEqual(wbinaryReader(2)(3), 6);
   });
 
   it('tests auto-currying on curried fixed function signature', function() {
     const wbinaryReader = RA.weaveLazy(curry(binaryReader), always(1));
 
-    eq(wbinaryReader(2, 3), 6);
-    eq(wbinaryReader(2)(3), 6);
+    assert.strictEqual(wbinaryReader(2, 3), 6);
+    assert.strictEqual(wbinaryReader(2)(3), 6);
   });
 
   it('tests auto-currying on variadic function signature', function() {
     const wvariadicReader = RA.weaveLazy(variadicReader, always(1));
 
-    eq(wvariadicReader(1, 2, 3), 7);
+    assert.strictEqual(wvariadicReader(1, 2, 3), 7);
   });
 
   it('tests auto-currying on curried variadic function signature', function() {
     const wvariadicReader = RA.weaveLazy(curry(variadicReader), always(1));
 
-    eq(wvariadicReader(1, 2, 3), 7);
+    assert.strictEqual(wvariadicReader(1, 2, 3), 7);
   });
 
   it('tests auto-currying on mixed function signature', function() {
     const wmixedReader = RA.weaveLazy(mixedReader, always(1));
 
-    eq(wmixedReader(2, 3, 4), 10);
-    eq(wmixedReader(2)(3, 4), 10);
+    assert.strictEqual(wmixedReader(2, 3, 4), 10);
+    assert.strictEqual(wmixedReader(2)(3, 4), 10);
   });
 
   it('tests auto-currying on curried mixed function signature', function() {
     const wmixedReader = RA.weaveLazy(curry(mixedReader), always(1));
 
-    eq(wmixedReader(2, 3, 4), 10);
-    eq(wmixedReader(2)(3, 4), 10);
+    assert.strictEqual(wmixedReader(2, 3, 4), 10);
+    assert.strictEqual(wmixedReader(2)(3, 4), 10);
   });
 });


### PR DESCRIPTION
Batch 21

test/
- stubUndefined.js
- subtractNum.js
- trimEnd.js
- trimStart.js
- trunc.js
- viewOr.js
- weave.js
- weaveLazy.js
- Y.js
