### PR TITLE
test(isNotPlainObj): add ramda placeholder and make tests consistent

### DIFF
--- a/test/isNotPlainObj.js
+++ b/test/isNotPlainObj.js
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import * as R from 'ramda';
 
 import * as RA from '../src';
 import element from './shared/element';
@@ -12,54 +13,79 @@ class Bar {
 }
 
 describe('isNotPlainObj', function() {
-  it('tests a value for POJO', function() {
-    assert.isFalse(RA.isNotPlainObj({}));
-    assert.isFalse(RA.isNotPlainObj({ prop: 'value' }));
-    assert.isFalse(RA.isNotPlainObj({ constructor: Bar }));
-    assert.isTrue(RA.isNotPlainObj(new Bar()));
-    assert.isTrue(RA.isNotPlainObj(['a', 'b', 'c']));
+  context('given a POJO value', function() {
+    specify('should return false', function() {
+      assert.isFalse(RA.isNotPlainObj({}));
+      assert.isFalse(RA.isNotPlainObj({ prop: 'value' }));
+      assert.isFalse(RA.isNotPlainObj({ constructor: Bar }));
+    });
   });
 
-  it('tests a value with prototype of null', function() {
-    assert.isFalse(RA.isNotPlainObj(Object.create(null)));
-
-    const object = Object.create(null);
-    object.constructor = Object.prototype.constructor;
-
-    assert.isFalse(RA.isNotPlainObj(object));
+  context('given a non-POJO value', function() {
+    specify('should return true', function() {
+      assert.isTrue(RA.isNotPlainObj(new Bar()));
+      assert.isTrue(RA.isNotPlainObj(['a', 'b', 'c']));
+    });
   });
 
-  it('tests a value with `valueOf` property', function() {
-    assert.isFalse(RA.isNotPlainObj({ valueOf: 1 }));
+  context('given a value with prototype of null', function() {
+    specify('should return false', function() {
+      assert.isFalse(RA.isNotPlainObj(Object.create(null)));
+
+      const object = Object.create(null);
+      object.constructor = Object.prototype.constructor;
+
+      assert.isFalse(RA.isNotPlainObj(object));
+    });
   });
 
-  it('test a value with custom prototype', function() {
-    assert.isFalse(RA.isNotPlainObj(Object.create({ a: 3 })));
+  context('given a value with `valueOf` property', function() {
+    specify('should return false', function() {
+      assert.isFalse(RA.isNotPlainObj({ valueOf: 1 }));
+    });
   });
 
-  it('test a value that is DOM element', function() {
-    if (element) {
-      assert.isTrue(RA.isNotPlainObj(element));
-    }
+  context('given a value with custom prototype', function() {
+    specify('should return false', function() {
+      assert.isFalse(RA.isNotPlainObj(Object.create({ a: 3 })));
+    });
   });
 
-  it('test a value for non-objects', function() {
-    assert.isTrue(RA.isNotPlainObj(args));
-    assert.isTrue(RA.isNotPlainObj(Error));
-    assert.isTrue(RA.isNotPlainObj(Math));
-    assert.isTrue(RA.isNotPlainObj(true));
-    assert.isTrue(RA.isNotPlainObj('abc'));
+  context('given a DOM elemen value', function() {
+    specify('should return true', function() {
+      if (element) {
+        assert.isTrue(RA.isNotPlainObj(element));
+      }
+    });
   });
 
-  it('test a value for Symbol', function() {
-    if (Symbol) {
-      assert.isTrue(RA.isNotPlainObj(Symbol.for('symbol')));
-    }
+  context('given a non-object value', function() {
+    specify('should return true', function() {
+      assert.isTrue(RA.isNotPlainObj(args));
+      assert.isTrue(RA.isNotPlainObj(Error));
+      assert.isTrue(RA.isNotPlainObj(Math));
+      assert.isTrue(RA.isNotPlainObj(true));
+      assert.isTrue(RA.isNotPlainObj('abc'));
+    });
+  });
+
+  context('given a symbol value', function() {
+    specify('should return true', function() {
+      if (Symbol !== 'undefined') {
+        assert.isTrue(RA.isNotPlainObj(Symbol.for('symbol')));
+      }
+    });
+  });
+
+  it('should support placeholder to specify "gaps"', function() {
+    const isNotPlainObj = RA.isNotPlainObj(R.__);
+
+    assert.isTrue(isNotPlainObj(null));
   });
 });
 
 describe('isNotPlainObject', function() {
-  it('tests an alias', function() {
+  it('should be an alias for isNotPlainObj', function() {
     assert.strictEqual(RA.isNotPlainObj, RA.isNotPlainObject);
   });
 });


### PR DESCRIPTION
Batch 5

@char0n, as I know the function must be curried to support Ramda placeholders. The isNotPlainObj function is a complement(isPlainObj). [isPlainObj](https://github.com/char0n/ramda-adjunct/blob/master/src/isPlainObj.js) looks like a normal arrow function, but placeholder works with it. I can't find a piece of code where isPlainObj was curried (or perhaps I missed something). May you please explain this to me?