### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/allEqual.js
+++ b/src/allEqual.js
@@ -1,5 +1,4 @@
-import { pipe, uniq } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { pipe, uniq, curryN } from 'ramda';
 
 import lengthLte from './lengthLte';
 
@@ -24,6 +23,6 @@ import lengthLte from './lengthLte';
  * RA.allEqual([]); //=> true
  *
  */
-const allEqual = curry1(pipe(uniq, lengthLte(1)));
+const allEqual = curryN(1, pipe(uniq, lengthLte(1)));
 
 export default allEqual;

--- a/src/allIdentical.js
+++ b/src/allIdentical.js
@@ -1,5 +1,4 @@
-import { uniqWith, identical, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { uniqWith, identical, pipe, curryN } from 'ramda';
 
 import lengthLte from './lengthLte';
 
@@ -22,6 +21,6 @@ import lengthLte from './lengthLte';
  * RA.allIdentical([ {}, {} ]); //=> false
  * RA.allIdentical([ () => {}, () => {} ]); //=> false
  */
-const allIdentical = curry1(pipe(uniqWith(identical), lengthLte(1)));
+const allIdentical = curryN(1, pipe(uniqWith(identical), lengthLte(1)));
 
 export default allIdentical;

--- a/src/allP.js
+++ b/src/allP.js
@@ -1,5 +1,4 @@
-import { bind } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, curryN } from 'ramda';
 
 /**
  * Composable shortcut for `Promise.all`.
@@ -23,6 +22,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.allP([Promise.resolve(1), Promise.resolve(2)]); //=> Promise([1, 2])
  * RA.allP([1, Promise.reject(2)]); //=> Promise(2)
  */
-const allP = curry1(bind(Promise.all, Promise));
+const allP = curryN(1, bind(Promise.all, Promise));
 
 export default allP;

--- a/src/allSettledP.js
+++ b/src/allSettledP.js
@@ -1,10 +1,9 @@
-import { bind } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, curryN } from 'ramda';
 
 import isFunction from './isFunction';
 import polyfill from './internal/polyfills/Promise.allSettled';
 
-export const allSettledPPolyfill = curry1(polyfill);
+export const allSettledPPolyfill = curryN(1, polyfill);
 
 /**
  * Returns a promise that is fulfilled with an array of promise state snapshots,
@@ -29,7 +28,7 @@ export const allSettledPPolyfill = curry1(polyfill);
  * ]); //=> Promise([{ status: 'fulfilled', value: 1 }, { status: 'fulfilled', value: 2 }, { status: 'rejected', reason: 3 }])
  */
 const allSettledP = isFunction(Promise.allSettled)
-  ? curry1(bind(Promise.allSettled, Promise))
+  ? curryN(1, bind(Promise.allSettled, Promise))
   : allSettledPPolyfill;
 
 export default allSettledP;

--- a/src/anyP.js
+++ b/src/anyP.js
@@ -1,10 +1,9 @@
-import { bind } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, curryN } from 'ramda';
 
 import isFunction from './isFunction';
 import polyfill, { AggregatedError } from './internal/polyfills/Promise.any';
 
-export const anyPPolyfill = curry1(polyfill);
+export const anyPPolyfill = curryN(1, polyfill);
 export { AggregatedError };
 
 /**
@@ -28,7 +27,7 @@ export { AggregatedError };
  * ]); //=> Promise(1)
  */
 const anyP = isFunction(Promise.any)
-  ? curry1(bind(Promise.any, Promise))
+  ? curryN(1, bind(Promise.any, Promise))
   : anyPPolyfill;
 
 export default anyP;


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
first batch of 5:
src/allEqual.js
src/allIdentical.js
src/allP.js
src/allSettledP.js
src/anyP.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
