### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/isAsyncFunction.js
+++ b/src/isAsyncFunction.js
@@ -1,5 +1,4 @@
-import { pipe, type, identical } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { pipe, type, identical, curryN } from 'ramda';
 
 /**
  * Checks if input value is `Async Function`.
@@ -19,6 +18,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isAsyncFunction(function test() { }); //=> false
  * RA.isAsyncFunction(() => {}); //=> false
  */
-const isAsyncFunction = curry1(pipe(type, identical('AsyncFunction')));
+const isAsyncFunction = curryN(1, pipe(type, identical('AsyncFunction')));
 
 export default isAsyncFunction;

--- a/src/isBoolean.js
+++ b/src/isBoolean.js
@@ -1,5 +1,4 @@
-import { type, identical, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { type, identical, pipe, curryN } from 'ramda';
 
 /**
  * Checks if input value is `Boolean`.
@@ -18,6 +17,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isBoolean(true); //=> true
  * RA.isBoolean(null); //=> false
  */
-const isBoolean = curry1(pipe(type, identical('Boolean')));
+const isBoolean = curryN(1, pipe(type, identical('Boolean')));
 
 export default isBoolean;

--- a/src/isDate.js
+++ b/src/isDate.js
@@ -1,5 +1,4 @@
-import { type, identical, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { type, identical, pipe, curryN } from 'ramda';
 
 /**
  * Checks if value is `Date` object.
@@ -17,6 +16,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isDate(new Date()); //=> true
  * RA.isDate('1997-07-16T19:20+01:00'); //=> false
  */
-const isDate = curry1(pipe(type, identical('Date')));
+const isDate = curryN(1, pipe(type, identical('Date')));
 
 export default isDate;

--- a/src/isEven.js
+++ b/src/isEven.js
@@ -1,5 +1,4 @@
-import { both, complement } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { both, complement, curryN } from 'ramda';
 
 import isInteger from './isInteger';
 import isOdd from './isOdd';
@@ -27,6 +26,6 @@ import isOdd from './isOdd';
  * RA.isEven(4); // => true
  * RA.isEven(3); // => false
  */
-const isEven = curry1(both(isInteger, complement(isOdd)));
+const isEven = curryN(1, both(isInteger, complement(isOdd)));
 
 export default isEven;

--- a/src/isFinite.js
+++ b/src/isFinite.js
@@ -1,10 +1,9 @@
-import { bind } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, curryN } from 'ramda';
 
 import isFunction from './isFunction';
 import polyfill from './internal/polyfills/Number.isFinite';
 
-export const isFinitePolyfill = curry1(polyfill);
+export const isFinitePolyfill = curryN(1, polyfill);
 
 /**
  * Checks whether the passed value is a finite `Number`.
@@ -32,7 +31,7 @@ export const isFinitePolyfill = curry1(polyfill);
  *                    // would've been true with global isFinite(null)
  */
 const _isFinite = isFunction(Number.isFinite)
-  ? curry1(bind(Number.isFinite, Number))
+  ? curryN(1, bind(Number.isFinite, Number))
   : isFinitePolyfill;
 
 export default _isFinite;


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
third batch of 5:
src/isAsyncFunction.js
src/isBoolean.js
src/isDate.js
src/isEven.js
src/isFinite.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
