### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/isGeneratorFunction.js
+++ b/src/isGeneratorFunction.js
@@ -1,5 +1,12 @@
-import curry1 from 'ramda/src/internal/_curry1';
-import { type, is, F as stubFalse, either, identical, pipe } from 'ramda';
+import {
+  type,
+  is,
+  F as stubFalse,
+  either,
+  identical,
+  pipe,
+  curryN,
+} from 'ramda';
 
 let GeneratorFunction = null;
 let legacyCheck = null;
@@ -28,7 +35,8 @@ try {
  * RA.isGeneratorFunction(function test() { }); //=> false
  * RA.isGeneratorFunction(() => {}); //=> false
  */
-const isGeneratorFunction = curry1(
+const isGeneratorFunction = curryN(
+  1,
   either(pipe(type, identical('GeneratorFunction')), legacyCheck)
 );
 

--- a/src/isIndexed.js
+++ b/src/isIndexed.js
@@ -1,5 +1,4 @@
-import { either } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { either, curryN } from 'ramda';
 
 import isArray from './isArray';
 import isString from './isString';
@@ -20,6 +19,6 @@ import isString from './isString';
  * RA.isIndexed('test') //=> true
  */
 
-const isIndexed = curry1(either(isString, isArray));
+const isIndexed = curryN(1, either(isString, isArray));
 
 export default isIndexed;

--- a/src/isInteger.js
+++ b/src/isInteger.js
@@ -1,10 +1,9 @@
-import { bind } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, curryN } from 'ramda';
 
 import isFunction from './isFunction';
 import polyfill from './internal/polyfills/Number.isInteger';
 
-export const isIntegerPolyfill = curry1(polyfill);
+export const isIntegerPolyfill = curryN(1, polyfill);
 
 /**
  * Checks whether the passed value is an `integer`.
@@ -35,7 +34,7 @@ export const isIntegerPolyfill = curry1(polyfill);
  * RA.isInteger([1]);       //=> false
  */
 const isInteger = isFunction(Number.isInteger)
-  ? curry1(bind(Number.isInteger, Number))
+  ? curryN(1, bind(Number.isInteger, Number))
   : isIntegerPolyfill;
 
 export default isInteger;

--- a/src/isIterable.js
+++ b/src/isIterable.js
@@ -1,5 +1,4 @@
-import { hasIn } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { hasIn, curryN } from 'ramda';
 
 import isFunction from './isFunction';
 
@@ -25,7 +24,7 @@ import isFunction from './isFunction';
  * RA.isIterable(null); //=> false
  * RA.isIterable(undefined); //=> false
  */
-const isIterable = curry1(val => {
+const isIterable = curryN(1, val => {
   if (typeof Symbol === 'undefined') {
     return false;
   }

--- a/src/isMap.js
+++ b/src/isMap.js
@@ -1,5 +1,4 @@
-import { type, identical, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { type, identical, pipe, curryN } from 'ramda';
 
 /**
  * Predicate for determining if a provided value is an instance of a Map.
@@ -21,6 +20,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isSet(new Object()); //=> false
  */
 
-const isMap = curry1(pipe(type, identical('Map')));
+const isMap = curryN(1, pipe(type, identical('Map')));
 
 export default isMap;


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
fourth batch of 5:
src/isGeneratorFunction.js
src/isIndexed.js
src/isInteger.js
src/isIterable.js
src/isMap.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
