### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/isNotFloat.js
+++ b/src/isNotFloat.js
@@ -1,5 +1,4 @@
-import { complement } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { complement, curryN } from 'ramda';
 
 import isFloat from './isFloat';
 
@@ -31,6 +30,6 @@ import isFloat from './isFloat';
  * RA.isNotFloat(false);     //=> true
  * RA.isNotFloat([1]);       //=> true
  */
-const isNotFloat = curry1(complement(isFloat));
+const isNotFloat = curryN(1, complement(isFloat));
 
 export default isNotFloat;

--- a/src/isNumber.js
+++ b/src/isNumber.js
@@ -1,5 +1,5 @@
 import _isNumber from 'ramda/src/internal/_isNumber';
-import curry1 from 'ramda/src/internal/_curry1';
+import { curryN } from 'ramda';
 
 /**
  * Checks if value is a `Number` primitive or object.
@@ -20,6 +20,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isNumber(NaN); // => true
  * RA.isNumber('5'); // => false
  */
-const isNumber = curry1(_isNumber);
+const isNumber = curryN(1, _isNumber);
 
 export default isNumber;

--- a/src/isObj.js
+++ b/src/isObj.js
@@ -1,5 +1,4 @@
-import { both, either } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { both, either, curryN } from 'ramda';
 
 import isNotNull from './isNotNull';
 import isFunction from './isFunction';
@@ -27,6 +26,6 @@ import isOfTypeObject from './internal/isOfTypeObject';
  * RA.isObj(undefined); //=> false
  */
 /* eslint-enable max-len */
-const isObj = curry1(both(isNotNull, either(isOfTypeObject, isFunction)));
+const isObj = curryN(1, both(isNotNull, either(isOfTypeObject, isFunction)));
 
 export default isObj;

--- a/src/isObjLike.js
+++ b/src/isObjLike.js
@@ -1,5 +1,4 @@
-import { both } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { both, curryN } from 'ramda';
 
 import isNotNull from './isNotNull';
 import isOfTypeObject from './internal/isOfTypeObject';
@@ -26,6 +25,6 @@ import isOfTypeObject from './internal/isOfTypeObject';
  * RA.isObjLike(undefined); //=> false
  */
 /* eslint-enable max-len */
-const isObjLike = curry1(both(isNotNull, isOfTypeObject));
+const isObjLike = curryN(1, both(isNotNull, isOfTypeObject));
 
 export default isObjLike;

--- a/src/isOdd.js
+++ b/src/isOdd.js
@@ -1,5 +1,4 @@
-import { both, pipe, modulo, flip, equals, complement } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { both, pipe, modulo, flip, equals, complement, curryN } from 'ramda';
 
 import isInteger from './isInteger';
 
@@ -22,7 +21,8 @@ import isInteger from './isInteger';
  * RA.isOdd(4); // => false
  * RA.isOdd(3); // => true
  */
-const isOdd = curry1(
+const isOdd = curryN(
+  1,
   both(isInteger, pipe(flip(modulo)(2), complement(equals)(0)))
 );
 


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
sixth batch of 5:
src/isNotFloat.js
src/isNumber.js
src/isObj.js
src/isObjLike.js
src/isOdd.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
