### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/isPair.js
+++ b/src/isPair.js
@@ -1,5 +1,4 @@
-import { both, equals, length, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { both, equals, length, pipe, curryN } from 'ramda';
 
 import isArray from './isArray';
 
@@ -23,6 +22,6 @@ import isArray from './isArray';
  * RA.isPair({ 0: 0, 1: 1 }); // => false
  * RA.isPair({ foo: 0, bar: 0 }); // => false
  */
-const isPair = curry1(both(isArray, pipe(length, equals(2))));
+const isPair = curryN(1, both(isArray, pipe(length, equals(2))));
 
 export default isPair;

--- a/src/isPlainObj.js
+++ b/src/isPlainObj.js
@@ -1,6 +1,5 @@
 import _isObject from 'ramda/src/internal/_isObject';
-import { pipe, both, equals, toString, pathSatisfies } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { pipe, both, equals, toString, pathSatisfies, curryN } from 'ramda';
 
 import isNull from './isNull';
 import isObjLike from './isObjLike';
@@ -40,7 +39,7 @@ const hasObjectConstructor = pathSatisfies(
  * RA.isPlainObj(new Object()); //=> true
  */
 /* eslint-enable max-len */
-const isPlainObj = curry1(val => {
+const isPlainObj = curryN(1, val => {
   if (!isObjLike(val) || !_isObject(val)) {
     return false;
   }

--- a/src/isPromise.js
+++ b/src/isPromise.js
@@ -1,5 +1,4 @@
-import { both, pipe, toString, equals } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { both, pipe, toString, equals, curryN } from 'ramda';
 
 import isObj from './isObj';
 
@@ -25,7 +24,8 @@ import isObj from './isObj';
  * RA.isPromise(Promise.reject()); // => true
  * RA.isPromise({ then: () => 1 }); // => false
  */
-const isPromise = curry1(
+const isPromise = curryN(
+  1,
   both(isObj, pipe(toString, equals('[object Promise]')))
 );
 

--- a/src/isRegExp.js
+++ b/src/isRegExp.js
@@ -1,5 +1,4 @@
-import { type, identical, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { type, identical, pipe, curryN } from 'ramda';
 
 /**
  * Checks if value is `RegExp` object.
@@ -18,6 +17,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isRegExp(/(?:)/); //=> true
  * RA.isRegExp(1); //=> false
  */
-const isRegExp = curry1(pipe(type, identical('RegExp')));
+const isRegExp = curryN(1, pipe(type, identical('RegExp')));
 
 export default isRegExp;

--- a/src/isSafeInteger.js
+++ b/src/isSafeInteger.js
@@ -1,10 +1,9 @@
-import { bind } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, curryN } from 'ramda';
 
 import isFunction from './isFunction';
 import polyfill from './internal/polyfills/Number.isSafeInteger';
 
-export const isSafeIntegerPolyfill = curry1(polyfill);
+export const isSafeIntegerPolyfill = curryN(1, polyfill);
 
 /**
  * Checks whether the passed value is a safe `integer`.
@@ -35,7 +34,7 @@ export const isSafeIntegerPolyfill = curry1(polyfill);
  */
 
 const isSafeInteger = isFunction(Number.isSafeInteger)
-  ? curry1(bind(Number.isSafeInteger, Number))
+  ? curryN(1, bind(Number.isSafeInteger, Number))
   : isSafeIntegerPolyfill;
 
 export default isSafeInteger;


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
seventh batch of 5:
src/isPair.js
src/isPlainObj.js
src/isPromise.js
src/isRegExp.js
src/isSafeInteger.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
