### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/isSet.js
+++ b/src/isSet.js
@@ -1,5 +1,4 @@
-import { type, identical, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { type, identical, pipe, curryN } from 'ramda';
 
 /**
  * Predicate for determining if a provided value is an instance of a Set.
@@ -20,6 +19,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isSet(new Object()); //=> false
  */
 
-const isSet = curry1(pipe(type, identical('Set')));
+const isSet = curryN(1, pipe(type, identical('Set')));
 
 export default isSet;

--- a/src/isString.js
+++ b/src/isString.js
@@ -1,5 +1,5 @@
 import _isString from 'ramda/src/internal/_isString';
-import curry1 from 'ramda/src/internal/_curry1';
+import { curryN } from 'ramda';
 
 /**
  * Checks if input value is `String`.
@@ -17,6 +17,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isString('abc'); //=> true
  * RA.isString(1); //=> false
  */
-const isString = curry1(_isString);
+const isString = curryN(1, _isString);
 
 export default isString;

--- a/src/isSymbol.js
+++ b/src/isSymbol.js
@@ -1,5 +1,4 @@
-import { type } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { type, curryN } from 'ramda';
 
 /**
  * Checks if input value is a Symbol.
@@ -20,7 +19,7 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isSymbol(undefined); //=> false
  * RA.isSymbol(null); //=> false
  */
-const isSymbol = curry1(val => {
+const isSymbol = curryN(1, val => {
   return (
     typeof val === 'symbol' ||
     (typeof val === 'object' && type(val) === 'Symbol')

--- a/src/isTruthy.js
+++ b/src/isTruthy.js
@@ -1,4 +1,4 @@
-import curry1 from 'ramda/src/internal/_curry1';
+import { curryN } from 'ramda';
 
 /**
  * In JavaScript, a `truthy` value is a value that is considered true
@@ -23,6 +23,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * RA.isTruthy(new Date()); // => true
  * RA.isTruthy(Infinity); // => true
  */
-const isTruthy = curry1(Boolean);
+const isTruthy = curryN(1, Boolean);
 
 export default isTruthy;

--- a/src/isValidDate.js
+++ b/src/isValidDate.js
@@ -1,5 +1,4 @@
-import { invoker, both, pipe } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { invoker, both, pipe, curryN } from 'ramda';
 
 import isDate from './isDate';
 import isNotNaN from './isNotNaN';
@@ -22,6 +21,9 @@ import isNotNaN from './isNotNaN';
  * RA.isValidDate(new Date('a')); //=> false
  */
 /* eslint-enable max-len */
-const isValidDate = curry1(both(isDate, pipe(invoker(0, 'getTime'), isNotNaN)));
+const isValidDate = curryN(
+  1,
+  both(isDate, pipe(invoker(0, 'getTime'), isNotNaN))
+);
 
 export default isValidDate;


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
eighth batch of 5:
src/isSet.js
src/isString.js
src/isSymbol.js
src/isTruthy.js
src/isValidDate.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
