### PR TITLE
refactor(src): remove curry1 dependency

### DIFF
--- a/src/isValidNumber.js
+++ b/src/isValidNumber.js
@@ -1,5 +1,4 @@
-import { either } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { either, curryN } from 'ramda';
 
 import isFloat from './isFloat';
 import isInteger from './isInteger';
@@ -24,6 +23,6 @@ import isInteger from './isInteger';
  * RA.isValidNumber(Infinity); //=> false
  * RA.isValidNumber(-Infinity); //=> false
  */
-const isValidNumber = curry1(either(isInteger, isFloat));
+const isValidNumber = curryN(1, either(isInteger, isFloat));
 
 export default isValidNumber;

--- a/src/lastP.js
+++ b/src/lastP.js
@@ -1,5 +1,4 @@
-import { bind, last, map } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { bind, last, map, curryN } from 'ramda';
 
 import allP from './allP';
 import lengthEq from './lengthEq';
@@ -30,7 +29,7 @@ import resolveP from './resolveP';
  *   delayP.reject(1000),
  * ]); //=> Promise(100)
  */
-const lastP = curry1(iterable => {
+const lastP = curryN(1, iterable => {
   const fulfilled = [];
   const rejected = [];
   const onFulfill = bind(fulfilled.push, fulfilled);

--- a/src/lensTraverse.js
+++ b/src/lensTraverse.js
@@ -1,5 +1,4 @@
-import { traverse, curry, pipe, prop } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { traverse, curry, pipe, prop, curryN } from 'ramda';
 
 import Identity from './fantasy-land/Identity';
 
@@ -36,7 +35,7 @@ import Identity from './fantasy-land/Identity';
  *
  * R.set(maybeLens, Maybe.Just(1), [Maybe.just(2), Maybe.Just(3)]); // => Maybe.Just([1, 1])
  */
-const lensTraverse = curry1(of =>
+const lensTraverse = curryN(1, of =>
   curry((toFunctorFn, target) =>
     Identity.of(traverse(of, pipe(toFunctorFn, prop('value')), target))
   )

--- a/src/liftF.js
+++ b/src/liftF.js
@@ -1,4 +1,4 @@
-import curry1 from 'ramda/src/internal/_curry1';
+import { curryN } from 'ramda';
 
 import liftFN from './liftFN';
 
@@ -32,6 +32,6 @@ import liftFN from './liftFN';
  * madd3(Maybe.Some(10), Maybe.Some(15), Maybe.Some(17)); //=> Maybe.Some(42)
  * madd3(Maybe.Some(10), Maybe.Nothing(), Maybe.Some(17)); //=> Maybe.Nothing()
  */
-const liftF = curry1(fn => liftFN(fn.length, fn));
+const liftF = curryN(1, fn => liftFN(fn.length, fn));
 
 export default liftF;

--- a/src/nonePass.js
+++ b/src/nonePass.js
@@ -1,5 +1,4 @@
-import { complement, compose, anyPass } from 'ramda';
-import curry1 from 'ramda/src/internal/_curry1';
+import { complement, compose, anyPass, curryN } from 'ramda';
 
 /**
  * Takes a list of predicates and returns a predicate that returns true for a given list of
@@ -28,6 +27,6 @@ import curry1 from 'ramda/src/internal/_curry1';
  * f(11); //=> false
  * f(9); //=> true
  */
-const nonePass = curry1(compose(complement, anyPass));
+const nonePass = curryN(1, compose(complement, anyPass));
 
 export default nonePass;


### PR DESCRIPTION
migrate from internal curry1 to standard curryN
ninth batch of 5:
src/isValidNumber.js
src/lastP.js
src/lensTraverse.js
src/liftF.js
src/nonePass.js

Ref #1340

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
