### PR TITLE
refactor(src): remove internal ramda dependency

### DIFF
--- a/src/isNumber.js
+++ b/src/isNumber.js
@@ -1,5 +1,4 @@
-import _isNumber from 'ramda/src/internal/_isNumber';
-import { curryN } from 'ramda';
+import { curryN, pipe, type, identical } from 'ramda';
 
 /**
  * Checks if value is a `Number` primitive or object.
@@ -20,6 +19,6 @@ import { curryN } from 'ramda';
  * RA.isNumber(NaN); // => true
  * RA.isNumber('5'); // => false
  */
-const isNumber = curryN(1, _isNumber);
+const isNumber = curryN(1, pipe(type, identical('Number')));
 
 export default isNumber;


### PR DESCRIPTION
replace _isNumber with:
const isNumber = R.pipe(R.type, R.identical('Number'));

Ref #1362

# Pull request template

Please use the following [PR](https://github.com/char0n/ramda-adjunct/pull/905/files) as an example
of pull request. This PR deals with adding a new feature called `allSettledP`.

If you have any additional questions please don't hesitate to contact any of the core committers.
