### PR TITLE
refactor: better typescript support

### DIFF
--- a/src/compact.js
+++ b/src/compact.js
@@ -4,7 +4,7 @@ import isFalsy from './isFalsy';
 
 /**
  * Creates an array with all falsy values removed.
- * The values false, null, 0, "", undefined, and NaN are falsy.
+ * Falsy values are `false`, `0`, `0n`, `''`, `null`, `undefined` and `NaN`.
  *
  * @func compact
  * @memberOf RA

--- a/src/isFalsy.js
+++ b/src/isFalsy.js
@@ -4,7 +4,7 @@ import isTruthy from './isTruthy';
 
 /**
  * A falsy value is a value that translates to false when evaluated in a Boolean context.
- * Falsy values are `false`, `0`, `""`, `null`, `undefined`, and `NaN`.
+ * Falsy values are `false`, `0`, `0n`, `''`, `null`, `undefined` and `NaN`.
  *
  * @func isFalsy
  * @memberOf RA

--- a/src/nand.js
+++ b/src/nand.js
@@ -10,7 +10,7 @@ import { and, complement } from 'ramda';
  * @sig a -> b -> Boolean
  * @param {*} a
  * @param {*} b
- * @return {Boolean} false if both arguments are truesy
+ * @return {Boolean} false if both arguments are truthy
  * @example
  *
  * RA.nand(true, true); //=> false

--- a/src/reduceP.js
+++ b/src/reduceP.js
@@ -6,7 +6,7 @@ import allP from './allP';
 
 /* eslint-disable max-len */
 /**
- * Given an `Iterable`(arrays are `Iterable`), or a promise of an `Iterable`,
+ * Given an `Iterable` (arrays are `Iterable`), or a promise of an `Iterable`,
  * which produces promises (or a mix of promises and values),
  * iterate over all the values in the `Iterable` into an array and
  * reduce the array to a value using the given iterator function.

--- a/src/reduceRightP.js
+++ b/src/reduceRightP.js
@@ -9,7 +9,7 @@ const flipArgs = pipe(reduceRight(concat, ''), equals('ba'))(['a', 'b']);
 
 /* eslint-disable max-len */
 /**
- * Given an `Iterable`(arrays are `Iterable`), or a promise of an `Iterable`,
+ * Given an `Iterable` (arrays are `Iterable`), or a promise of an `Iterable`,
  * which produces promises (or a mix of promises and values),
  * iterate over all the values in the `Iterable` into an array and
  * reduce the array to a value using the given iterator function.

--- a/src/zipObjWith.js
+++ b/src/zipObjWith.js
@@ -17,7 +17,7 @@ import { apply, curryN, fromPairs, map, pipe, zip } from 'ramda';
  * @see {@link https://ramdajs.com/docs/#zipObj|zipObj}, {@link RA.unzipObjWith|unzipObjWith}
  * @example
  *
- * RA.zipObjWith((value, key) => [key, `${key}${value + 1}`]), ['a', 'b', 'c'], [1, 2, 3]);
+ * RA.zipObjWith((value, key) => [key, `${key}${value + 1}`], ['a', 'b', 'c'], [1, 2, 3]);
  *  // => { a: 'a2', b: 'b3', c: 'c4' }
  */
 const zipObjWith = curryN(3, (fn, keys, values) =>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-declare var RA: RamdaAdjunct.Static;
-// TypeScript Version: 2.4
+declare const RA: RamdaAdjunct.Static;
+// TypeScript Version: 3.5
 
 declare namespace RamdaAdjunct {
     interface Functor<T> {
@@ -20,12 +20,12 @@ declare namespace RamdaAdjunct {
     }
 
     interface Catamorphism<T> {
-        cata<T1>(leftFn: (v: T1) => T, rightFn: (v: T1) => T): T;
+        cata<U>(leftFn: (v: U) => T, rightFn: (v: U) => T): T;
     }
 
     enum SettledPromiseStatus {
-        Fulfilled = "fulfilled",
-        Rejected = "rejected",
+        Fulfilled = 'fulfilled',
+        Rejected = 'rejected',
     }
 
     interface SettledPromise<T> {
@@ -33,340 +33,375 @@ declare namespace RamdaAdjunct {
         value: T;
     }
 
-    type Variadic<T1, T2> = (...args: T1[]) => T2;
+    type KeyTypes = number | string | symbol;
 
-    type Pred = (...a: any[]) => boolean;
+    type Primitive = boolean | number | string;
 
-    interface Dictionary<T> { [key: string]: T; }
+    type Defined<T> = T extends undefined ? never : T;
 
-    type DictPred<T> = (value: T, key: string) => boolean;
+    type Dictionary<T = unknown> = Record<KeyTypes, T>;
+
+    type Intersect<U> =
+    (U extends unknown ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never;
+
+    export type ObjectKeys<T extends Dictionary> = {
+        [K in keyof T]-?: Defined<T[K]> extends object ? K : never;
+    }[keyof T];
+
+    type ValueOf<T> = T[keyof T];
+
+    type DictionaryPredicate<T extends Dictionary> = (value: ValueOf<T>, key: keyof T) => boolean;
+
+    type MergedProperties<T, U> = {
+        [K in (keyof T & keyof U)]: undefined extends T[K] ? Defined<T[K] | U[K]> : T[K]
+    };
+
+    type MergeLeft<T, U> = Omit<T, keyof U> & Omit<U, keyof T> & MergedProperties<U, T>;
+
+    type MergeProps<T extends Dictionary, U extends keyof T> = Omit<T, U> & Intersect<T[U]>;
+
+    type Pair<T = unknown, U = unknown> = [T, U];
+
+    type Predicate = (...args: readonly unknown[]) => boolean;
+
+    type Awaited<T> = T extends Promise<infer U> ? U : T;
+
+    type Unboxed<T> =
+        T extends (infer U)[] ? U : T[Extract<keyof T, number>];
+
+    type Variadic<T, U> = (...args: readonly T[]) => U;
+
+    // tslint:disable-next-line:no-null-undefined-union
+    type Nil = null | undefined;
+
+    // tslint:disable-next-line:no-null-undefined-union
+    type NilOrEmpty = Nil | '';
+
+    // tslint:disable-next-line:no-null-undefined-union
+    type Falsy = NilOrEmpty | false | 0 | 0n;
 
     interface Static {
         /**
          * Checks if input value is `Array`.
          */
-        isArray(val: any): val is any[];
+        isArray(val: unknown): val is unknown[];
 
         /**
          * Checks whether the passed value is iterable.
          */
-        isIterable<T>(val: any): val is Iterable<T>;
+        isIterable(val: unknown): val is Iterable<unknown>;
 
         /**
          * Checks if input value is an empty `Array`.
          */
-        isEmptyArray(val: any): val is any[];
+        isEmptyArray(val: unknown): val is unknown[];
 
         /**
          * Checks if input value is `Boolean`.
          */
-        isBoolean(val: any): val is boolean;
+        isBoolean(val: unknown): val is boolean;
 
         /**
          * Returns `true` if the given value is its type's empty value, `null` or `undefined`.
          */
-        isNilOrEmpty(val: any): boolean;
+        isNilOrEmpty(val: unknown): val is NilOrEmpty;
 
         /**
          * Returns `true` if the given value is not its type's empty value, nor `null` nor `undefined`.
          */
-        isNotNilOrEmpty(val: any): boolean;
+        isNotNilOrEmpty<T>(val: T): val is Exclude<T, NilOrEmpty>;
 
         /**
          * Checks if input value is complement of `Array`.
          */
-        isNotArray(val: any): boolean;
+        isNotArray<T>(val: T): val is Exclude<T, unknown[]>;
 
         /**
          * Checks if input value is a non empty `Array`.
          */
-        isNonEmptyArray(val: any): val is any[];
+        isNonEmptyArray(val: unknown): val is unknown[];
 
         /**
          * Checks if input value is complement of `Boolean`.
          */
-        isNotBoolean(val: any): boolean;
+        isNotBoolean<T>(val: T): val is Exclude<T, boolean>;
 
         /**
          * Returns true if the given value is not its type's empty value; `false` otherwise.
          */
-        isNotEmpty(val: any): boolean;
+        isNotEmpty<T>(val: T): val is Exclude<T, ''>;
 
         /**
          * Checks if input value is complement of `null` or `undefined`.
          */
-        isNotNil(val: any): boolean;
+        isNotNil<T>(val: T): val is Exclude<T, Nil>;
 
         /**
          * Checks if input value is complement of `null`.
          */
-        isNotNull(val: any): boolean;
+        isNotNull<T>(val: T): val is Exclude<T, null>;
 
         /**
          * Checks if input value is complement of `String`.
          */
-        isNotString(val: any): boolean;
+        isNotString<T>(val: T): val is Exclude<T, string>;
 
         /**
          * Checks if input value is a non empty `String`.
          */
-        isNonEmptyString(val: any): boolean;
+        isNonEmptyString<T>(val: T): val is Exclude<T, ''>;
 
         /**
          * Checks if input value is complement `undefined`.
          */
-        isNotUndefined(val: any): boolean;
+        isNotUndefined<T>(val: T): val is Exclude<T, undefined>;
 
         /**
          * Checks if input value is `Symbol`.
          */
-        isSymbol(val: any): val is Symbol;
+        isSymbol(val: unknown): val is symbol;
 
         /**
          * Checks if input value is `null`.
          */
-        isNull(val: any): val is null;
+        isNull(val: unknown): val is null;
 
         /**
          * Checks if input value is `String`.
          */
-        isString(val: any): val is string;
+        isString(val: unknown): val is string;
 
         /**
          * Checks if input value is an empty `String`.
          */
-        isEmptyString(val: any): val is string;
+        isEmptyString(val: unknown): val is '';
 
         /**
          * Checks if input value is `undefined`.
          */
-        isUndefined(val: any): val is undefined;
+        isUndefined(val: unknown): val is undefined;
 
         /**
          * Tests whether or not an object is similar to an array.
          */
-        isArrayLike(val: any): boolean;
+        isArrayLike(val: unknown): val is ArrayLike<unknown>;
 
         /**
          * Tests whether or not an object is similar to an array.
          */
-        isNotArrayLike(val: any): boolean;
+        isNotArrayLike<T>(val: T): val is Exclude<T, ArrayLike<unknown>>;
 
         /**
          * Checks if input value is `Generator Function`.
          */
-        isGeneratorFunction(val: any): val is Function;
+        isGeneratorFunction(val: unknown): val is Function;
 
         /**
          * Checks if input value is complement of `Generator Function`.
          */
-        isNotGeneratorFunction(val: any): boolean;
+        isNotGeneratorFunction<T>(val: T): val is Exclude<T, Function>;
 
         /**
          * Checks if input value is `Async Function`.
          */
-        isAsyncFunction(val: any): val is Function;
+        isAsyncFunction(val: unknown): val is Function;
 
         /**
          * Checks if input value is complement of `Async Function`.
          */
-        isNotAsyncFunction(val: any): boolean;
+        isNotAsyncFunction<T>(val: T): val is Exclude<T, Function>;
 
         /**
          * Checks if input value is `Function`.
          */
-        isFunction(val: any): val is Function;
+        isFunction(val: unknown): val is Function;
 
         /**
          * Checks if input value is complement of `Function`.
          */
-        isNotFunction(val: any): boolean;
+        isNotFunction<T>(val: T): val is Exclude<T, Function>;
 
         /**
          * Checks if input value is language type of `Object`.
          */
-        isObj(val: any): val is {} | Function;
-        isObject(val: any): val is {} | Function; // alias
+        isObj(val: unknown): val is object;
+        isObject(val: unknown): val is object; // alias
 
         /**
          * Checks if input value is complement of language type of `Object`.
          */
-        isNotObj(val: any): boolean;
-        isNotObject(val: any): boolean; // alias
+        isNotObj<T>(val: T): val is Exclude<T, object>;
+        isNotObject<T>(val: T): val is Exclude<T, object>; // alias
 
         /**
          * Checks if value is object-like. A value is object-like if it's not null and has a typeof result of "object".
          */
-        isObjLike(val: any): val is object;
-        isObjectLike(val: any): val is object; // alias
+        isObjLike<T>(val: T): val is object & Exclude<T, Function>;
+        isObjectLike<T>(val: T): val is object & Exclude<T, Function>; // alias
 
         /**
          * Checks if value is not object-like.
          * A value is object-like if it's not null and has a typeof result of "object".
          */
-        isNotObjLike(val: any): boolean;
-        isNotObjectLike(val: any): boolean; // alias
+        isNotObjLike<T>(val: T): val is Extract<T, Function | Nil | Primitive>;
+        isNotObjectLike<T>(val: T): val is Extract<T, Function | Nil | Primitive>; // alias
 
         /**
          * Check to see if an object is a plain object (created using `{}`, `new Object()` or `Object.create(null)`).
          */
-        isPlainObj(val: any): val is object;
-        isPlainObject(val: any): val is object; // alias
+        isPlainObj(val: unknown): val is Dictionary;
+        isPlainObject(val: unknown): val is Dictionary; // alias
 
         /**
          * Check to see if an object is not a plain object
          * (created using `{}`, `new Object()` or `Object.create(null)`).
          */
-        isNotPlainObj(val: any): boolean;
-        isNotPlainObject(val: any): boolean; // alias
+        isNotPlainObj<T>(val: T): val is Exclude<T, Dictionary>;
+        isNotPlainObject<T>(val: T): val is Exclude<T, Dictionary>; // alias
 
         /**
          * Checks if value is `Date` object.
          */
-        isDate(val: any): val is Date;
+        isDate(val: unknown): val is Date;
 
         /**
          * Checks if value is complement of `Date` object.
          */
-        isNotDate(val: any): boolean;
+        isNotDate<T>(val: T): val is Exclude<T, Date>;
 
         /**
          * Checks if value is valid `Date` object.
          */
-        isValidDate(val: any): val is Date;
+        isValidDate(val: unknown): val is Date;
 
         /**
          * Checks if value is complement of valid `Date` object.
          */
-        isNotValidDate(val: any): boolean;
-
-        /**
-         * Checks if value is complement of valid `Date` object.
-         */
-        isInvalidDate(val: any): boolean; // alias of isNotValidDate
+        isNotValidDate(val: unknown): boolean;
+        isInvalidDate(val: unknown): boolean; // alias
 
         /**
          * Checks if value is `Map`.
          */
-        isMap(val: any): val is Map<any, any>;
+        isMap(val: unknown): val is Map<unknown, unknown>;
 
         /**
          * Checks if value is complement of `Map` object.
          */
-        isNotMap(val: any): boolean;
+        isNotMap<T>(val: T): val is Exclude<T, Map<unknown, unknown>>;
 
         /**
          * Checks whether the passed value is `NaN` and its type is `Number`.
          * It is a more robust version of the original, global isNaN().
          */
-        isNaN(val: any): val is typeof NaN;
+        isNaN(val: unknown): boolean;
 
         /**
          * Checks whether the passed value is complement of `NaN` and its type is not `Number`.
          */
-        isNotNaN(val: any): boolean;
+        isNotNaN(val: unknown): boolean;
 
         /**
          * Checks if value is a `Number` primitive or object.
          */
-        isNumber(val: any): val is number;
+        isNumber(val: unknown): val is number;
 
         /**
          * Checks if value is a complement of `Number` primitive or object.
          */
-        isNotNumber(val: any): boolean;
+        isNotNumber<T>(val: T): val is Exclude<T, number>;
 
         /**
          * Checks if value is a positive `Number` primitive or object. Zero is considered neither
          * positive or negative.
          */
-        isPositive(val: any): val is number;
+        isPositive(val: unknown): val is number;
 
         /**
          * Checks if value is a negative `Number` primitive or object. Zero is considered neither
          * positive or negative.
          */
-        isNegative(val: any): val is number;
+        isNegative(val: unknown): val is number;
 
         /**
          * Checks if value is a positive zero (+0).
          */
-        isPositiveZero(val: any): boolean;
+        isPositiveZero(val: unknown): val is number;
 
         /**
          * Checks if value is a negative zero (-0).
          */
-        isNegativeZero(val: any): boolean;
+        isNegativeZero(val: unknown): val is number;
 
         /**
          * Checks if value is a non-positive `Number` primitive or object. This includes all
          * negative numbers and zero.
          */
-        isNonPositive(val: any): val is number;
+        isNonPositive(val: unknown): boolean;
 
         /**
          * Checks if value is a non-negative `Number` primitive or object. This includes all
          * positive numbers and zero.
          */
-        isNonNegative(val: any): val is number;
+        isNonNegative(val: unknown): boolean;
 
         /**
          * Checks whether the passed value is a finite `Number`.
          */
-        isFinite(val: any): boolean;
+        isFinite(val: unknown): val is number;
 
         /**
          * Checks whether the passed value is complement of finite `Number`.
          */
-        isNotFinite(val: any): boolean;
+        isNotFinite(val: unknown): boolean;
 
         /**
          * Checks whether the passed value is an `integer`.
          */
-        isInteger(val: any): val is number;
+        isInteger(val: unknown): val is number;
 
         /**
          * Checks whether the passed value is complement of `integer`.
          */
-        isNotInteger(val: any): boolean;
+        isNotInteger<T>(val: T): val is Exclude<T, number>;
 
         /**
          * Checks if value is a BigInt.
          */
-        isBigInt(val: any): boolean;
+        isBigInt(val: unknown): val is bigint;
 
         /**
          * Checks whether the passed value is a `float`.
          */
-        isFloat(val: any): val is number;
+        isFloat(val: unknown): val is number;
 
         /**
          * Checks whether the passed value is a safe `integer`.
          */
-        isSafeInteger(val: any): boolean;
+        isSafeInteger(val: unknown): val is number;
 
         /**
          * Checks whether the passed value is complement of a `float`.
          */
-        isNotFloat(val: any): boolean;
+        isNotFloat(val: unknown): boolean;
 
         /**
          * Checks if value is a valid `Number`. A valid `Number` is a number that is not `NaN`,
          * `Infinity` or `-Infinity`.
          */
-        isValidNumber(val: any): boolean;
+        isValidNumber(val: unknown): val is number;
 
         /**
          * Checks if value is not a valid `Number`. A valid `Number` is a number that is not `NaN`,
          * `Infinity` or `-Infinity`.
          */
-        isNotValidNumber(val: any): boolean;
+        isNotValidNumber(val: unknown): boolean;
 
         /**
          * Checks if value is odd integer number.
          * An odd number is an integer which is not a multiple DIVISIBLE of two.
          */
-        isOdd(val: any): boolean;
+        isOdd(val: unknown): val is number;
 
         /**
          * Checks if value is even integer number.
@@ -375,37 +410,37 @@ declare namespace RamdaAdjunct {
          * which despite not being a natural number, is an integer.
          * Even numbers are either positive or negative.
          */
-        isEven(val: any): boolean;
+        isEven(val: unknown): val is number;
 
         /**
          * Checks if input value is a pair.
          */
-        isPair(val: any): val is any[];
+        isPair(val: unknown): val is Pair;
 
         /**
          * Checks if input value is complement of a pair.
          */
-        isNotPair(val: any): boolean;
+        isNotPair<T>(val: T): val is Exclude<T, Pair>;
 
         /**
          * Checks if value is `RegExp` object.
          */
-        isRegExp(val: any): boolean;
-
-        /**
-         * Checks if value is `Set`.
-         */
-        isSet(val: any): val is Set<any>;
-
-        /**
-         * Checks if value is complement of `Set` object.
-         */
-        isNotSet(val: any): boolean;
+        isRegExp(val: unknown): val is RegExp;
 
         /**
          * Checks if value is complement of `RegExp` object.
          */
-        isNotRegExp(val: any): boolean;
+        isNotRegExp<T>(val: T): val is Exclude<T, RegExp>;
+
+        /**
+         * Checks if value is `Set`.
+         */
+        isSet(val: unknown): val is Set<unknown>;
+
+        /**
+         * Checks if value is complement of `Set` object.
+         */
+        isNotSet<T>(val: T): val is Exclude<T, Set<unknown>>;
 
         /**
          * Checks if input value is a sparse Array.
@@ -413,7 +448,49 @@ declare namespace RamdaAdjunct {
          * Empty slot doesn't mean that the slot contains `null` or `undefined` values,
          * but rather that the slots don't exist.
          */
-        isSparseArray(val: any): boolean;
+        isSparseArray(val: unknown): val is unknown[];
+
+        /**
+         * Determine if input value is an indexed data type.
+         */
+        isIndexed(val: unknown): val is string | unknown[];
+
+        /**
+         * Checks if input value is a `thenable`.
+         * `thenable` is an object or function that defines a `then` method.
+         */
+        isThenable(val: unknown): val is Function | { then: () => unknown };
+
+        /**
+         * Checks if input value is a native `Promise`.
+         * The Promise object represents the eventual completion (or failure)
+         * of an asynchronous operation, and its resulting value.
+         */
+        isPromise(val: unknown): val is Promise<unknown>;
+
+        /**
+         * Checks if input value is the Boolean primitive `true`. Will return false for Boolean
+         * objects created using the `Boolean` function as a constructor.
+         */
+        isTrue(val: unknown): val is true;
+
+        /**
+         * Checks if input value is the Boolean primitive `false`. Will return false for Boolean objects created using the `Boolean` function as a constructor.
+         */
+        isFalse(val: unknown): val is false;
+
+        /**
+         * In JavaScript, a `truthy` value is a value that is considered true
+         * when evaluated in a Boolean context. All values are truthy unless
+         * they are defined as falsy (i.e., except for `false`, `0`, `0n`, `''`, `null`, `undefined` and `NaN`).
+         */
+        isTruthy<T>(val: T): val is Exclude<T, Falsy>;
+
+        /**
+         * A falsy value is a value that translates to false when evaluated in a Boolean context.
+         * Falsy values are `false`, `0`, `0n`, `''`, `null`, `undefined` and `NaN`.
+         */
+        isFalsy(val: unknown): val is Falsy;
 
         /**
          * A function that returns `undefined`.
@@ -428,40 +505,40 @@ declare namespace RamdaAdjunct {
         /**
          * A function that returns new empty array on every call.
          */
-        stubArray(): any[];
+        stubArray(): unknown[];
 
         /**
          * This function returns a new empty object.
          */
-        stubObj(): {};
-        stubObject(): {}; // alias
+        stubObj(): object;
+        stubObject(): object; // alias
 
         /**
          * A function that returns empty string.
          */
-        stubString(): "";
+        stubString(): '';
 
         /**
          * A function that performs no operations.
          */
-        noop(...args: any[]): undefined;
+        noop(...args: readonly unknown[]): undefined;
 
         /**
          * Picks values from list by indexes.
          */
-        pickIndexes<T>(indexes: number[], list: T[]): T[];
-        pickIndexes(indexes: number[]): <T>(list: T[]) => T[];
+        pickIndexes<T>(indexes: readonly number[], list: readonly T[]): T[];
+        pickIndexes(indexes: readonly number[]): <T>(list: readonly T[]) => T[];
 
         /**
          * Creates a list from from arguments.
          */
-        list(...items: any[]): any[];
+        list(...items: readonly unknown[]): unknown[];
 
         /**
          * Returns a singleton array containing the value provided.
          * If value is already an array, it is returned as is.
          */
-        ensureArray<T>(value: T | T[]): T[];
+        ensureArray<T>(val: T | readonly T[]): T[];
 
         /**
          * Returns the result of concatenating the given lists or strings.
@@ -471,40 +548,40 @@ declare namespace RamdaAdjunct {
          * Can also concatenate multiple elements of a [fantasy-land compatible semigroup](https://github.com/fantasyland/fantasy-land#semigroup).
          * Returns undefined if empty array was passed.
          */
-        concatAll<S extends Semigroup>(foldable: Foldable<S>): S | undefined;
+        concatAll<T extends Semigroup>(foldable: Foldable<T>): T | undefined;
 
         /**
          * Returns the result of concatenating the given lists or strings.
          */
-        concatRight<T extends any[]>(firstList: T, secondList: T): T;
-        concatRight<T extends any[]>(firstList: T): (secondList: T) => T;
         concatRight(firstList: string, secondList: string): string;
         concatRight(firstList: string): (secondList: string) => string;
+        concatRight<T>(firstList: readonly T[], secondList: readonly T[]): T[];
+        concatRight<T>(firstList: readonly T[]): (secondList: readonly T[]) => T[];
 
         /**
          * Acts as multiple path: arrays of paths in, array of values out. Preserves order.
          */
-        paths(ps: Array<Array<string | number>>, obj: object): any[];
-        paths(ps: Array<Array<string | number>>): (obj: object) => any[];
+        paths(ps: readonly KeyTypes[][], obj: Dictionary): unknown[];
+        paths(ps: readonly KeyTypes[][]): (obj: Dictionary) => unknown[];
 
         /**
          * If the given, non-null object has a value at the given path, returns the value at that path.
          * Otherwise returns the result of invoking the provided function with the object.
          */
-        pathOrLazy<T>(
-            defaultValueFn: () => T,
-            path: Array<number | string>,
-            obj: object
-        ): T;
-        pathOrLazy<T>(
-            defaultValueFn: () => T,
-            path: Array<number | string>
-        ): (obj: object) => T;
-        pathOrLazy<T>(
-            defaultValueFn: () => T
+        pathOrLazy(
+            defaultValueFn: Function,
+            path: readonly KeyTypes[],
+            obj: Dictionary
+        ): unknown;
+        pathOrLazy(
+            defaultValueFn: Function,
+            path: readonly KeyTypes[],
+        ): (obj: Dictionary) => unknown;
+        pathOrLazy(
+            defaultValueFn: Function
         ): {
-            (path: Array<number | string>, obj: object): T;
-            (path: Array<number | string>): (obj: object) => T;
+            (path: readonly KeyTypes[], obj: Dictionary): unknown;
+            (path: readonly KeyTypes[]): (obj: Dictionary) => unknown;
         };
 
         /**
@@ -545,15 +622,15 @@ declare namespace RamdaAdjunct {
          * keys renamed according to the keysMap object as `{oldKey: newKey}`.
          * When some key is not found in the keysMap, then it's passed as-is.
          */
-        renameKeys(keysMap: Dictionary<string>, obj: object): object;
-        renameKeys(keysMap: Dictionary<string>): (obj: object) => object;
+        renameKeys<T extends Dictionary>(keysMap: Partial<Record<keyof T, KeyTypes>>, obj: T): Record<KeyTypes, ValueOf<T>>;
+        renameKeys<T extends Dictionary>(keysMap: Partial<Record<keyof T, KeyTypes>>): (obj: T) => Record<KeyTypes, ValueOf<T>>;
 
         /**
          * Creates a new object with the own properties of the provided object, but the
          * keys renamed according to logic of renaming function.
          */
-        renameKeysWith(renameFn: (key: string) => string, obj: object): object;
-        renameKeysWith(renameFn: (key: string) => string): (obj: object) => object;
+        renameKeysWith<T extends Dictionary>(renameFn: (key: keyof T) => KeyTypes, obj: T): Record<KeyTypes, ValueOf<T>>;
+        renameKeysWith<T extends Dictionary>(renameFn: (key: keyof T) => KeyTypes): (obj: T) => Record<KeyTypes, ValueOf<T>>;
 
         /**
          * Create a new object with the own properties of the second object merged with
@@ -561,35 +638,35 @@ declare namespace RamdaAdjunct {
          * the value from the first object will be used. *
          * Putting it simply: it sets properties only if they don't exist.
          */
-        mergeRight(source: object, destination: object): object;
-        mergeRight(source: object): (destination: object) => object;
-        mergeLeft(source: object, destination: object): object; // alias
-        mergeLeft(source: object): (destination: object) => object; // alias
-        resetToDefault(defaultOptions: object, options: object): object; // alias of mergeRight
-        resetToDefault(defaultOptions: object): (options: object) => object; // alias of mergeRight
+        mergeRight<T extends Dictionary, U extends Dictionary>(source: T, destination: T): MergeLeft<T, U>;
+        mergeRight<T extends Dictionary, U extends Dictionary>(source: T): (destination: T) => MergeLeft<T, U>;
+        mergeLeft<T extends Dictionary, U extends Dictionary>(source: T, destination: T): MergeLeft<T, U>; // alias
+        mergeLeft<T extends Dictionary, U extends Dictionary>(source: T): (destination: T) => MergeLeft<T, U>; // alias
+        resetToDefault<T extends Dictionary, U extends Dictionary>(source: T, destination: T): MergeLeft<T, U>; // alias
+        resetToDefault<T extends Dictionary, U extends Dictionary>(source: T): (destination: T) => MergeLeft<T, U>; // alias
 
         /**
          * Functional equivalent of merging object properties with object spread.
          */
-        mergeProps(ps: string[], obj: object): object;
-        mergeProps(ps: string[]): (obj: object) => object;
+        mergeProps<T extends Dictionary, U extends ObjectKeys<T>>(keys: readonly U[], obj: T): MergeProps<T, U>;
+        mergeProps<T extends Dictionary, U extends ObjectKeys<T>>(keys: readonly U[]): (obj: T) => MergeProps<T, U>;
 
         /**
          * Merge objects under corresponding paths.
          */
-        mergePaths(paths: Array<Array<string | number>>, obj: object): object;
-        mergePaths(paths: Array<Array<string | number>>): (obj: object) => object;
+        mergePaths<T extends Dictionary>(paths: readonly KeyTypes[][], obj: T): Partial<T>;
+        mergePaths(paths: readonly KeyTypes[][]): <T extends Dictionary>(obj: T) => Partial<T>;
 
         /**
          * Create a new object with the own properties of the object under the `p`
          * merged with the own properties of the provided `source`.
          * If a key exists in both objects, the value from the `source` object will be used.
          */
-        mergeProp(p: string, source: object, obj: object): object;
-        mergeProp(p: string, source: object): (obj: object) => object;
-        mergeProp(p: string): {
-            (source: object, obj: object): object;
-            (source: object): (obj: object) => object;
+        mergeProp<T extends Dictionary, U extends Dictionary>(key: keyof U, source: T, obj: U): Partial<T & U>;
+        mergeProp<T extends Dictionary, U extends Dictionary>(key: keyof U, source: T): (obj: U) => Partial<T & U>;
+        mergeProp<T extends Dictionary, U extends Dictionary>(key: keyof U): {
+            (source: T, obj: U): Partial<T & U>;
+            (source: T): (obj: U) => Partial<T & U>;
         };
 
         /**
@@ -597,25 +674,25 @@ declare namespace RamdaAdjunct {
          * merged with the own properties of the provided `source`.
          * If a key exists in both objects, the value from the `source` object will be used.
          */
-        mergePath(path: Array<string | number>, source: object, obj: object): object;
-        mergePath(path: Array<string | number>, source: object): (obj: object) => object;
-        mergePath(path: Array<string | number>): {
-            (source: object, obj: object): object;
-            (source: object): (obj: object) => object;
+        mergePath<T extends Dictionary, U extends Dictionary>(path: readonly KeyTypes[], source: T, obj: U): Partial<T & U>;
+        mergePath<T extends Dictionary>(path: readonly KeyTypes[], source: T): <U extends Dictionary>(obj: U) => Partial<T & U>;
+        mergePath(path: readonly KeyTypes[]): {
+            <T extends Dictionary, U extends Dictionary>(source: T, obj: U): Partial<T & U>;
+            <T extends Dictionary>(source: T): <U extends Dictionary>(obj: U) => Partial<T & U>;
         };
 
         /**
          * Returns a partial copy of an object containing only the keys
          * that don't satisfy the supplied predicate.
          */
-        omitBy<T, U extends Dictionary<T>>(pred: DictPred<T>, obj: U): U;
-        omitBy<T, U extends Dictionary<T>>(pred: DictPred<T>): (obj: U) => U;
+        omitBy<T extends Dictionary>(pred: DictionaryPredicate<T>, obj: T): Partial<T>;
+        omitBy<T extends Dictionary>(pred: DictionaryPredicate<T>): (obj: T) => Partial<T>;
 
         /**
          * Weave a configuration into function returning the runnable monad like `Reader` or `Free`.
          */
-        weave(fn: Function, config: any): Function;
-        weave(fn: Function): (config: any) => Function;
+        weave(fn: Function, config: unknown): Function;
+        weave(fn: Function): (config: unknown) => Function;
 
         /**
          * Weave a configuration into function returning the runnable monad like `Reader` or `Free`.
@@ -640,55 +717,63 @@ declare namespace RamdaAdjunct {
          * {@link http://ramdajs.com/docs/#map|R.map} function that more closely resembles Array.prototype.map.
          * It takes two new parameters to its callback function: the current index, and the entire list.
          */
-        mapIndexed<T, U>(iterator: (elem: T, key: number, list: T[]) => U, list: ReadonlyArray<T>): U[];
-        mapIndexed<T, U>(iterator: (elem: T, key: number, list: T[]) => U): (list: ReadonlyArray<T>) => U[];
-        mapIndexed<T, U>(
-            iterator: (elem: T, key: number, list: Dictionary<T>) => U,
-            list: Dictionary<T>,
-        ): Dictionary<U>;
-        mapIndexed<T, U>(
-            iterator: (elem: T, key: number, list: Dictionary<T>) => U,
-        ): (list: Dictionary<T>) => Dictionary<U>;
-        mapIndexed<T, U>(iterator: (elem: T, key: number, list: Functor<T>) => U, list: Functor<T>): Functor<U>;
-        mapIndexed<T, U>(iterator: (elem: T, key: number, list: Functor<T>) => U): (list: Functor<T>) => Functor<U>;
-        mapIndexed(iterator: (char: string, key: number, str: string) => string, str: string): string[];
-        mapIndexed(iterator: (char: string, key: number, str: string) => string): (str: string) => string[];
+        mapIndexed(fn: (char: string, key: number, str: string) => string, str: string): string[];
+        mapIndexed(fn: (char: string, key: number, str: string) => string): (str: string) => string[];
+        mapIndexed<TSource, TResult>(fn: (elem: TSource, key: number, list: readonly TSource[]) => TResult, list: readonly TSource[]): TResult[];
+        mapIndexed<TSource, TResult>(fn: (elem: TSource, key: number, list: readonly TSource[]) => TResult): (list: readonly TSource[]) => TResult[];
+        mapIndexed<TSource, TResult>(
+            fn: (elem: TSource, key: number, list: Dictionary<TSource>) => TResult,
+            list: Dictionary<TSource>,
+        ): Dictionary<TResult>;
+        mapIndexed<TSource, TResult>(
+            fn: (elem: TSource, key: number, list: Dictionary<TSource>) => TResult,
+        ): (list: Dictionary<TSource>) => Dictionary<TResult>;
+        mapIndexed<TSource, TResult>(fn: (elem: TSource, key: number, list: Functor<TSource>) => TResult, list: Functor<TSource>): Functor<TResult>;
+        mapIndexed<TSource, TResult>(fn: (elem: TSource, key: number, list: Functor<TSource>) => TResult): (list: Functor<TSource>) => Functor<TResult>;
 
         /**
          * {@link http://ramdajs.com/docs/#reduce|R.reduce} function that more closely resembles Array.prototype.reduce.
          * It takes two new parameters to its callback function: the current index, and the entire list.
          */
-        reduceIndexed<T, TResult, R extends T[]>(
-            iterator: (acc: TResult, elem: T, key: number, list: R) => TResult,
-            acc: TResult,
-            list: R,
-        ): TResult;
-        reduceIndexed<T, TResult, R extends T[]>(
-            iterator: (acc: TResult, elem: T, key: number, list: R) => TResult,
-            acc: TResult,
-        ): (list: R) => TResult;
-        reduceIndexed<T, TResult, R extends T[]>(
-            iterator: (acc: TResult, elem: T, key: number, list: R) => TResult,
+        reduceIndexed<TSource, TAccumulator>(
+            fn: (acc: TAccumulator, elem: TSource, key: number, list: readonly TSource[]) => TAccumulator,
+            acc: TAccumulator,
+            list: readonly TSource[],
+        ): TAccumulator;
+        reduceIndexed<TSource, TAccumulator>(
+            fn: (acc: TAccumulator, elem: TSource, key: number, list: readonly TSource[]) => TAccumulator,
+            acc: TAccumulator,
+        ): (list: readonly TSource[]) => TAccumulator;
+        reduceIndexed<TSource, TAccumulator>(
+            fn: (acc: TAccumulator, elem: TSource, key: number, list: readonly TSource[]) => TAccumulator,
         ): {
-            (acc: TResult): (list: R) => TResult;
-            (acc: TResult, list: R): TResult
+            (acc: TAccumulator): (list: readonly TSource[]) => TAccumulator;
+            (acc: TAccumulator, list: readonly TSource[]): TAccumulator
         };
 
         /**
-         * Given an `Iterable`(arrays are `Iterable`), or a promise of an `Iterable`,
+         * Given an `Iterable` (arrays are `Iterable`), or a promise of an `Iterable`,
          * which produces promises (or a mix of promises and values),
          * iterate over all the values in the `Iterable` into an array and
          * reduce the array to a value using the given iterator function.
          */
-        reduceP<T, TResult, R extends T[]>(fn: (acc: TResult, elem: T) => TResult, acc: TResult, list: R): TResult;
-        reduceP<T, TResult, R extends T[]>(fn: (acc: TResult, elem: T) => TResult, acc: TResult): (list: R) => TResult;
-        reduceP<T, TResult, R extends T[]>(fn: (acc: TResult, elem: T) => TResult): {
-            (acc: TResult, list: R): TResult;
-            (acc: TResult): (list: R) => TResult
+        reduceP<TSource, TAccumulator, TResult>(
+            fn: (acc: TAccumulator, elem: TSource) => TResult,
+            acc: TAccumulator,
+            list: readonly TSource[]
+        ): TResult | Promise<Awaited<TResult>>;
+        reduceP<TSource, TAccumulator, TResult>(
+            fn: (acc: TAccumulator, elem: TSource) => TResult,
+            acc: TAccumulator
+        ): (list: readonly TSource[]) => TResult | Promise<Awaited<TResult>>;
+        reduceP<TSource, TAccumulator, TResult>(
+            fn: (acc: TAccumulator, elem: TSource) => TResult): {
+            (acc: TAccumulator, list: readonly TSource[]): TResult;
+            (acc: TAccumulator): (list: readonly TSource[]) => TResult | Promise<Awaited<TResult>>;
         };
 
         /**
-         * Given an `Iterable`(arrays are `Iterable`), or a promise of an `Iterable`,
+         * Given an `Iterable` (arrays are `Iterable`), or a promise of an `Iterable`,
          * which produces promises (or a mix of promises and values),
          * iterate over all the values in the `Iterable` into an array and
          * reduce the array to a value using the given iterator function.
@@ -697,58 +782,60 @@ declare namespace RamdaAdjunct {
          * The iterator function receives two values: (value, acc),
          * while the arguments' order of reduceP's iterator function is (acc, value).
          */
-        reduceRightP<T, TResult, R extends T[]>(
-            fn: (elem: T, acc: TResult) => TResult,
-            acc: TResult,
-            list: R,
-        ): TResult;
-        reduceRightP<T, TResult, R extends T[]>(
-            fn: (elem: T, acc: TResult) => TResult,
-            acc: TResult,
-        ): (list: R) => TResult;
-        reduceRightP<T, TResult, R extends T[]>(fn: (elem: T, acc: TResult) => TResult): {
-            (acc: TResult, list: R): TResult;
-            (acc: TResult): (list: R) => TResult
+        reduceRightP<TSource, TAccumulator, TResult>(
+            fn: (acc: TAccumulator, elem: TSource) => TResult,
+            acc: TAccumulator,
+            list: readonly TSource[]
+        ): TResult | Promise<Awaited<TResult>>;
+        reduceRightP<TSource, TAccumulator, TResult>(
+            fn: (acc: TAccumulator, elem: TSource) => TResult,
+            acc: TAccumulator
+        ): (list: readonly TSource[]) => TResult | Promise<Awaited<TResult>>;
+        reduceRightP<TSource, TAccumulator, TResult>(
+            fn: (acc: TAccumulator, elem: TSource) => TResult): {
+            (acc: TAccumulator, list: readonly TSource[]): TResult;
+            (acc: TAccumulator): (list: readonly TSource[]) => TResult | Promise<Awaited<TResult>>;
         };
+
         /**
          * Returns `true` if data structure focused by the given lens equals provided value.
          */
-        lensEq(lens: Function, value: any, data: any): boolean;
-        lensEq(lens: Function, value: any): (data: any) => boolean;
-        lensEq(lens: Function): (value: any) => (data: any) => boolean;
+        lensEq(lens: Function, value: unknown, data: unknown): boolean;
+        lensEq(lens: Function, value: unknown): (data: unknown) => boolean;
+        lensEq(lens: Function): (value: unknown) => (data: unknown) => boolean;
 
         /**
          * Returns `false` if data structure focused by the given lens equals provided value.
          */
-        lensNotEq(lens: Function, value: any, data: any): boolean;
-        lensNotEq(lens: Function, value: any): (data: any) => boolean;
-        lensNotEq(lens: Function): (value: any) => (data: any) => boolean;
+        lensNotEq(lens: Function, value: unknown, data: unknown): boolean;
+        lensNotEq(lens: Function, value: unknown): (data: unknown) => boolean;
+        lensNotEq(lens: Function): (value: unknown) => (data: unknown) => boolean;
 
         /**
          * Returns `true` if data structure focused by the given lens satisfies the predicate.
          * Note that the predicate is expected to return boolean value and will be evaluated
          * as `false` unless the predicate returns `true`.
          */
-        lensSatisfies(predicate: Function, lens: Function, data: any): boolean;
-        lensSatisfies(predicate: Function, lens: Function): (data: any) => boolean;
-        lensSatisfies(predicate: Function): (lens: Function) => (data: any) => boolean;
+        lensSatisfies(predicate: Function, lens: Function, data: unknown): boolean;
+        lensSatisfies(predicate: Function, lens: Function): (data: unknown) => boolean;
+        lensSatisfies(predicate: Function): (lens: Function) => (data: unknown) => boolean;
 
         /**
          * Returns `true` if data structure focused by the given lens doesn't satisfy the predicate.
          * Note that the predicate is expected to return boolean value.
          */
-        lensNotSatisfy(predicate: Function, lens: Function, data: any): boolean;
-        lensNotSatisfy(predicate: Function, lens: Function): (data: any) => boolean;
-        lensNotSatisfy(predicate: Function): (lens: Function) => (data: any) => boolean;
+        lensNotSatisfy(predicate: Function, lens: Function, data: unknown): boolean;
+        lensNotSatisfy(predicate: Function, lens: Function): (data: unknown) => boolean;
+        lensNotSatisfy(predicate: Function): (lens: Function) => (data: unknown) => boolean;
 
         /**
          * Returns a "view" of the given data structure, determined by the given lens
          * The lens's focus determines which portion of the data structure is visible.
          * Returns the defaultValue if "view" is null, undefined or NaN; otherwise the "view" is returned.
          */
-        viewOr(defaultValue: any, lens: Function, data: any): any;
-        viewOr(defaultValue: any, lens: Function): (data: any) => any;
-        viewOr(defaultValue: any): (lens: Function) => (data: any) => any;
+        viewOr(defaultValue: unknown, lens: Function, data: unknown): unknown;
+        viewOr(defaultValue: unknown, lens: Function): (data: unknown) => unknown;
+        viewOr(defaultValue: unknown): (lens: Function) => (data: unknown) => unknown;
 
         /**
          * Defines an isomorphism that will work like a lens. It takes two functions.
@@ -777,22 +864,22 @@ declare namespace RamdaAdjunct {
          * Returns true if the specified object property is not equal,
          * in R.equals terms, to the given value; false otherwise.
          */
-        propNotEq(prop: string | number, value: any, obj: object): boolean;
-        propNotEq(prop: string | number, value: any): (obj: object) => boolean;
-        propNotEq(prop: string | number): {
-            (value: any, obj: object): boolean;
-            (value: any): (obj: object) => boolean;
+        propNotEq<T extends Dictionary, U extends keyof T>(prop: U, value: T[U], obj: T): boolean;
+        propNotEq<T extends Dictionary, U extends keyof T>(prop: U, value: T[U]): (obj: T) => boolean;
+        propNotEq<T extends Dictionary, U extends keyof T>(prop: U): {
+            (value: T[U], obj: T): boolean;
+            (value: T[U]): (obj: T) => boolean;
         };
 
         /**
          * Determines whether a nested path on an object doesn't have a specific value,
          * in R.equals terms. Most likely used to filter a list.
          */
-        pathNotEq(path: Array<string | number>, value: any, obj: object): boolean;
-        pathNotEq(path: Array<string | number>, value: any): (obj: object) => boolean;
-        pathNotEq(path: Array<string | number>): {
-            (value: any, obj: object): boolean;
-            (value: any): (obj: object) => boolean;
+        pathNotEq(path: readonly KeyTypes[], value: unknown, obj: Dictionary): boolean;
+        pathNotEq(path: readonly KeyTypes[], value: unknown): (obj: Dictionary) => boolean;
+        pathNotEq(path: readonly KeyTypes[]): {
+            (value: unknown, obj: Dictionary): boolean;
+            (value: unknown): (obj: Dictionary) => boolean;
         };
 
         /**
@@ -808,50 +895,50 @@ declare namespace RamdaAdjunct {
         /**
          * Returns whether or not an object has an own property with the specified name at a given path.
          */
-        hasPath(path: Array<string | number>, obj: object): boolean;
-        hasPath(path: Array<string | number>): (obj: object) => boolean;
+        hasPath(path: readonly KeyTypes[]): (obj: Dictionary) => boolean;
+        hasPath(path: readonly KeyTypes[], obj: Dictionary): boolean;
 
         /**
          * Spreads object under property path onto provided object.
          */
-        spreadPath(path: Array<string | number>, obj: object): object;
-        spreadPath(path: Array<string | number>): (obj: object) => object;
+        spreadPath<T extends Dictionary>(path: readonly KeyTypes[], obj: T): Partial<T>;
+        spreadPath<T extends Dictionary>(path: readonly KeyTypes[]): (obj: T) => Partial<T>;
 
         /**
          * Spreads object under property onto provided object.
          */
-        spreadProp(prop: string | number, obj: object): object;
-        spreadProp(prop: string | number): (obj: object) => object;
+        spreadProp<T extends Dictionary, U extends ObjectKeys<T>>(prop: U, obj: T): Omit<T, U> & T[U];
+        spreadProp<T extends Dictionary, U extends ObjectKeys<T>>(prop: U): (obj: T) => Omit<T, U> & T[U];
 
         /**
          * Flattens a property path so that its fields are spread out into the provided object.
          */
-        flattenPath(path: Array<string | number>, obj: object): object;
-        flattenPath(path: Array<string | number>): (obj: object) => object;
+        flattenPath<T extends Dictionary>(path: readonly KeyTypes[], obj: T): T & Dictionary;
+        flattenPath(path: readonly KeyTypes[]): <T extends Dictionary>(obj: T) => T & Dictionary;
 
         /**
          * Flattens a property so that its fields are spread out into the provided object.
          */
-        flattenProp(prop: string | number, obj: object): object;
-        flattenProp(prop: string | number): (obj: object) => object;
+        flattenProp<T extends Dictionary, U extends ObjectKeys<T>>(prop: U, obj: T): T & T[U];
+        flattenProp<T extends Dictionary, U extends ObjectKeys<T>>(prop: U): (obj: T) => T & T[U];
 
         /**
          * Creates a new object out of a list of keys and a list of values by applying the function
          * to each equally-positioned pair in the lists.
          * Key/value pairing is truncated to the length of the shorter of the two lists.
          */
-        zipObjWith<T, U, V>(fn: (value: T, key: U) => [string, V], keys: U[], values: T[]): { [k: string]: V };
-        zipObjWith<T, U, V>(fn: (value: T, key: U) => [string, V]): (keys: U[], values: T[]) => { [k: string]: V };
-        zipObjWith<T, U, V>(fn: (value: T, key: U) => [string, V]): {
-            (keys: U[], values: T[]): { [k: string]: V };
-            (keys: U[]): (values: T[]) => { [k: string]: V };
+        zipObjWith<T, U extends KeyTypes>(fn: (value: Unboxed<T[]>, key: U) => Pair, keys: readonly U[], values: readonly T[]): Dictionary;
+        zipObjWith<T, U extends KeyTypes>(fn: (value: Unboxed<T[]>, key: U) => Pair): (keys: readonly U[], values: readonly T[]) => Dictionary;
+        zipObjWith<T, U extends KeyTypes>(fn: (value: Unboxed<T[]>, key: U) => Pair): {
+            (keys: readonly U[], values: readonly T[]): Dictionary;
+            (keys: readonly U[]): (values: readonly T[]) => Dictionary;
         };
 
         /**
          * Creates a new list out of the supplied object by applying the function to each key/value pairing.
          */
-        unzipObjWith<T, U, V>(fn: (v: T, k: string) => [U, V], obj: { [k: string]: T }): [U[], V[]];
-        unzipObjWith<T, U, V>(fn: (v: T, k: string) => [U, V]): (obj: { [k: string]: T }) => [U[], V[]];
+        unzipObjWith<T extends Dictionary, U, V>(fn: (value: ValueOf<T>, key: keyof T) => Pair<U, V>, obj: T): [U[], V[]];
+        unzipObjWith<T extends Dictionary, U, V>(fn: (value: ValueOf<T>, key: keyof T) => Pair<U, V>): (obj: T) => [U[], V[]];
 
         /**
          * Composable shortcut for `Promise.all`.
@@ -873,7 +960,7 @@ declare namespace RamdaAdjunct {
          * but only after all the original promises have settled, i.e. become either fulfilled or rejected.
          * We say that a promise is settled if it is not pending, i.e. if it is either fulfilled or rejected.
          */
-        allSettledP<T>(iterable: Iterable<T>): Promise<Array<SettledPromise<T>>>;
+        allSettledP<T>(iterable: Iterable<T>): Promise<SettledPromise<T>[]>;
 
         /**
          * Returns a promise that is fulfilled by the first given promise to be fulfilled,
@@ -895,14 +982,14 @@ declare namespace RamdaAdjunct {
          * If the value is a thenable (i.e. has a "then" method), the returned promise will
          * "follow" that thenable, adopting its eventual state.
          */
-        resolveP<T>(value?: T): Promise<T>;
+        resolveP<T>(val?: T): Promise<T>;
 
         /**
          * Composable shortcut for `Promise.reject`.
          *
          * Returns a Promise object that is rejected with the given reason.
          */
-        rejectP<T>(value?: T): Promise<T>;
+        rejectP<T>(val?: T): Promise<T>;
 
         /**
          * Creates a promise which resolves/rejects after the specified milliseconds.
@@ -929,9 +1016,9 @@ declare namespace RamdaAdjunct {
          * The thenCatchP function returns a Promise. It takes three arguments: a callback function for the success of the Promise,
          * a callback function for the failure of the Promise, and the promise instance itself.
          */
-        thenCatchP<A, B>(onFulfilled: Function, onRejected: (error: any) => B | Promise<B>, thenable: Promise<A>): Promise<A | B>;
-        thenCatchP<A, B>(onFulfilled: Function, onRejected: (error: any) => B | Promise<B>): (thenable: Promise<A>) => Promise<A | B>;
-        thenCatchP<A, B>(onFulfilled: Function): (onRejected: (error: any) => B | Promise<B>) => (thenable: Promise<A>) => Promise<A | B>;
+        thenCatchP<T, U>(onFulfilled: Function, onRejected: (error: unknown) => U | Promise<U>, thenable: Promise<T>): Promise<T | U>;
+        thenCatchP<T, U>(onFulfilled: Function, onRejected: (error: unknown) => U | Promise<U>): (thenable: Promise<T>) => Promise<T | U>;
+        thenCatchP<T, U>(onFulfilled: Function): (onRejected: (error: unknown) => U | Promise<U>) => (thenable: Promise<T>) => Promise<T | U>;
 
         /**
          * Runs the given list of functions in order with the supplied object, then returns the object.
@@ -939,75 +1026,79 @@ declare namespace RamdaAdjunct {
          *
          * Acts as a transducer if a transformer is given as second parameter.
          */
-        seq<T>(fns: Function[], x: T): T;
-        seq<T>(fns: Function[]): (x: T) => T;
-        sequencing<T>(fns: Function[], x: T): T; // alias
-        sequencing<T>(fns: Function[]): (x: T) => T; // alias
+        seq<T>(fns: readonly Function[], x: T): T;
+        seq(fns: readonly Function[]): <T>(x: T) => T;
+        sequencing<T>(fns: readonly Function[], x: T): T; // alias
+        sequencing(fns: readonly Function[]): <T>(x: T) => T; // alias
 
         /**
          * Returns the elements of the given list or string (or object with a slice method)
          * from fromIndex (inclusive).
          * Dispatches to the slice method of the third argument, if present.
          */
-        sliceFrom<T>(fromIndex: number, list: string | T[]): string | T[];
-        sliceFrom(fromIndex: number): <T>(list: string | T[]) => string | T[];
+        sliceFrom(fromIndex: number, list: string): string;
+        sliceFrom(fromIndex: number): (list: string) => string;
+        sliceFrom<T>(fromIndex: number, list: readonly T[]): T[];
+        sliceFrom(fromIndex: number): <T>(list: readonly T[]) => T[];
 
         /**
          * Returns the elements of the given list or string (or object with a slice method)
          * to toIndex (exclusive).
          * Dispatches to the slice method of the second argument, if present.
          */
-        sliceTo<T>(toIndex: number, list: string | T[]): string | T[];
-        sliceTo(toIndex: number): <T>(list: string | T[]) => string | T[];
+        sliceTo(toIndex: number, list: string): string;
+        sliceTo(toIndex: number): (list: string) => string;
+        sliceTo<T>(toIndex: number, list: readonly T[]): T[];
+        sliceTo(toIndex: number): <T>(list: readonly T[]) => T[];
 
         /**
          * Returns a partial copy of an array omitting the indexes specified.
          */
-        omitIndexes<T>(indexes: number[], list: T[]): T[];
-        omitIndexes(indexes: number[]): <T>(list: T[]) => T[];
+        omitIndexes<T>(indexes: readonly number[], list: readonly T[]): T[];
+        omitIndexes(indexes: readonly number[]): <T>(list: readonly T[]) => T[];
 
         /**
          * Returns `true` if the supplied list or string has a length greater than `valueLength`.
          */
-        lengthGt<T>(valueLength: number, list: string | T[]): boolean;
-        lengthGt(valueLength: number): <T>(list: string | T[]) => boolean;
+        lengthGt(valueLength: number, list: string | readonly unknown[]): boolean;
+        lengthGt(valueLength: number): (list: string | readonly unknown[]) => boolean;
 
         /**
          * Returns `true` if the supplied list or string has a length less than `valueLength`.
          */
-        lengthLt<T>(valueLength: number, list: string | T[]): boolean;
-        lengthLt(valueLength: number): <T>(list: string | T[]) => boolean;
+        lengthLt(valueLength: number, list: string | readonly unknown[]): boolean;
+        lengthLt(valueLength: number): (list: string | readonly unknown[]) => boolean;
 
         /**
          * Returns `true` if the supplied list or string has a length less than or equal to
          * `valueLength`.
          */
-        lengthLte<T>(valueLength: number, list: string | T[]): boolean;
-        lengthLte(valueLength: number): <T>(list: string | T[]) => boolean;
+        lengthLte(valueLength: number, list: string | readonly unknown[]): boolean;
+        lengthLte(valueLength: number): (list: string | readonly unknown[]) => boolean;
 
         /**
          * Returns `true` if the supplied list or string has a length greater than or equal to
          * `valueLength`.
          */
-        lengthGte<T>(valueLength: number, list: string | T[]): boolean;
-        lengthGte(valueLength: number): <T>(list: string | T[]) => boolean;
+        lengthGte(valueLength: number, list: string | readonly unknown[]): boolean;
+        lengthGte(valueLength: number): (list: string | readonly unknown[]) => boolean;
 
         /**
          * Returns `true` if the supplied list or string has a length equal to `valueLength`.
          */
-        lengthEq<T>(valueLength: number, list: string | T[]): boolean;
-        lengthEq(valueLength: number): <T>(list: string | T[]) => boolean;
+        lengthEq(valueLength: number, list: string | readonly unknown[]): boolean;
+        lengthEq(valueLength: number): (list: string | readonly unknown[]) => boolean;
 
         /**
          * Returns `true` if the supplied list or string has a length not equal to `valueLength`.
          */
-        lengthNotEq<T>(valueLength: number, list: string | T[]): boolean;
-        lengthNotEq(valueLength: number): <T>(list: string | T[]) => boolean;
+        lengthNotEq(valueLength: number, list: string | readonly unknown[]): boolean;
+        lengthNotEq(valueLength: number): (list: string | readonly unknown[]) => boolean;
 
         /**
          *  Returns true if all items in the list are equivalent using `R.equals` for equality comparisons.
          */
-        allEqual<T>(list: T[]): boolean;
+        allEqual(list: readonly unknown[]): boolean;
 
         /**
          * Constructs and returns a new string which contains the specified
@@ -1019,70 +1110,33 @@ declare namespace RamdaAdjunct {
         /*
          * Returns true if all items in the list are equivalent using `R.identical` for equality comparisons.
          */
-        allIdentical<T>(list: T[]): boolean;
+        allIdentical(list: readonly unknown[]): boolean;
 
         /*
          * Returns true if all items in the list are equivalent to user provided value using `R.identical` for equality comparisons.
          */
-        allIdenticalTo<T>(val: T, list: T[]): boolean;
-        allIdenticalTo<T>(val: T): (list: T[]) => boolean;
+        allIdenticalTo<T>(val: T, list: readonly T[]): boolean;
+        allIdenticalTo<T>(val: T): (list: readonly T[]) => boolean;
 
         /*
          * Returns true if all items in the list are equivalent to user provided value using `R.equals` for equality comparisons.
          */
-        allEqualTo<T>(val: T, list: T[]): boolean;
-        allEqualTo<T>(val: T): <T>(list: T[]) => boolean;
+        allEqualTo<T>(val: T, list: readonly T[]): boolean;
+        allEqualTo<T>(val: T): (list: readonly T[]) => boolean;
 
         /*
          * Flattens the list to the specified depth.
          */
-        flattenDepth<T>(depth: number, list: T[]): T[];
-        flattenDepth(depth: number): (list: any[]) => any[];
-
-        /**
-         * Checks if input value is a `thenable`.
-         * `thenable` is an object or function that defines a `then` method.
-         */
-        isThenable(val: any): boolean;
-
-        /**
-         * Checks if input value is a native `Promise`.
-         * The Promise object represents the eventual completion (or failure)
-         * of an asynchronous operation, and its resulting value.
-         */
-        isPromise(val: any): val is Promise<any>;
-
-        /**
-         * Checks if input value is the Boolean primitive `true`. Will return false for Boolean
-         * objects created using the `Boolean` function as a constructor.
-         */
-        isTrue(val: any): boolean;
-
-        /**
-         * Checks if input value is the Boolean primitive `false`. Will return false for Boolean objects created using the `Boolean` function as a constructor.
-         */
-        isFalse(val: any): boolean;
-
-        /**
-         * In JavaScript, a `truthy` value is a value that is considered true
-         * when evaluated in a Boolean context. All values are truthy unless
-         * they are defined as falsy (i.e., except for `false`, `0`, `""`, `null`, `undefined`, and `NaN`).
-         */
-        isTruthy(val: any): boolean;
-
-        /**
-         * A falsy value is a value that translates to false when evaluated in a Boolean context.
-         * Falsy values are `false`, `0`, `""`, `null`, `undefined`, and `NaN`.
-         */
-        isFalsy(val: any): boolean;
+        flattenDepth<T>(depth: number, list: readonly T[]): T[];
+        flattenDepth(depth: number): <T>(list: readonly T[]) => T[];
 
         /**
          * Returns the second argument if predicate function returns `true`,
          * otherwise the third argument is returned.
          */
-        defaultWhen<DefVal, Val>(predicate: Function, defaultVal: DefVal, val: Val): DefVal | Val;
-        defaultWhen<DefVal, Val>(predicate: Function, defaultVal: DefVal): (val: Val) => DefVal | Val;
-        defaultWhen(predicate: Function): <DefVal, Val>(defaultVal: DefVal) => (val: Val) => DefVal | Val;
+        defaultWhen<T, U>(predicate: Predicate, defaultVal: T, val: U): T | U;
+        defaultWhen<T, U>(predicate: Predicate, defaultVal: T): (val: U) => T | U;
+        defaultWhen(predicate: Predicate): <T, U>(defaultVal: T) => (val: U) => T | U;
 
         /**
          * Y-combinator
@@ -1103,7 +1157,7 @@ declare namespace RamdaAdjunct {
          * In addition to functions, `RA.notBoth` also accepts any fantasy-land compatible
          * applicative functor.
          */
-        notBoth(firstPredicate: Function, secondPredicate: Function): Function;
+        notBoth(firstPredicate: Predicate, secondPredicate: Predicate): Predicate;
 
         /**
          * A function which calls the two provided functions and returns the complement of `||`ing
@@ -1115,19 +1169,19 @@ declare namespace RamdaAdjunct {
          * In addition to functions, `RA.neither` also accepts any fantasy-land compatible
          * applicative functor.
          */
-        neither(firstPredicate: Function, secondPredicate: Function): Function;
+        neither(firstPredicate: Predicate, secondPredicate: Predicate): Predicate;
 
         /**
-         * Returns false if both arguments are truesy; true otherwise.
+         * Returns false if both arguments are truthy; true otherwise.
          */
-        nand(a: any, b: any): Boolean;
-        nand(a: any): (b: any) => Boolean;
+        nand(a: unknown, b: unknown): boolean;
+        nand(a: unknown): (b: unknown) => boolean;
 
         /**
          * Returns true if both arguments are falsy; false otherwise.
          */
-        nor(a: any, b: any): Boolean;
-        nor(a: any): (b: any) => Boolean;
+        nor(a: unknown, b: unknown): boolean;
+        nor(a: unknown): (b: unknown) => boolean;
 
         /**
          * Takes a list of predicates and returns a predicate that returns true for a given list of
@@ -1137,17 +1191,17 @@ declare namespace RamdaAdjunct {
          * The function returned is a curried function whose arity matches that of the
          * highest-arity predicate.
          */
-        notAllPass(predicates: Function[]): Function;
+        notAllPass(predicates: readonly Predicate[]): Predicate;
 
         /**
          * Takes a list of predicates and returns a predicate that returns true for a given list of
          * arguments if none of the provided predicates are satisfied by those arguments. It is the
-         * complement of Ramda's anyPass.
+         * complement of Ramda's unknownPass.
          *
          * The function returned is a curried function whose arity matches that of the
          * highest-arity predicate.
          */
-        nonePass(predicates: Function[]): Function;
+        nonePass(predicates: readonly Predicate[]): Predicate;
 
         /**
          * Takes a combining predicate and a list of functions and returns a function which will map
@@ -1161,15 +1215,15 @@ declare namespace RamdaAdjunct {
          * more arguments than functions, any remaining arguments are passed in to the combining
          * predicate untouched.
          */
-        argsPass<T>(combiningPredicate: (fn: (a: T) => boolean) => (list: T[]) => boolean, predicates: Pred[]): Pred;
-        argsPass<T>(combiningPredicate: (fn: (a: T) => boolean) => (list: T[]) => boolean): (predicates: Pred[]) => Pred;
+        argsPass<T>(combiningPredicate: (fn: (a: T) => boolean) => (list: readonly T[]) => boolean, predicates: readonly Predicate[]): Predicate;
+        argsPass<T>(combiningPredicate: (fn: (a: T) => boolean) => (list: readonly T[]) => boolean): (predicates: readonly Predicate[]) => Predicate;
 
         /**
          * Returns a function which is called with the given arguments. If any of the given arguments are null or undefined,
          * the corresponding default value for that argument is used instead.
          */
-        fnull(fn: Function, defaults: any[]): Function;
-        fnull(fn: Function): (defaults: any[]) => Function;
+        fnull(fn: Function, defaults: readonly unknown[]): Function;
+        fnull(fn: Function): (defaults: readonly unknown[]) => Function;
 
         /**
          * Accepts a function with any arity and returns a function with arity of zero.
@@ -1179,17 +1233,17 @@ declare namespace RamdaAdjunct {
 
         /**
          * Creates an array with all falsy values removed.
-         * The values false, null, 0, "", undefined, and NaN are falsy.
+         * Falsy values are `false`, `0`, `0n`, `''`, `null`, `undefined` and `NaN`.
          */
-        compact<T>(list: T[]): Array<NonNullable<T>>;
+        compact<T>(list: readonly T[]): Exclude<T, Falsy>[];
 
         /**
          * Returns a new list containing the contents of the given list, followed by the given
          * element. Like {@link http://ramdajs.com/docs/#append|R.append} but with argument order
          * reversed.
          */
-        appendFlipped<T>(list: T[], val: any): T[];
-        appendFlipped<T>(list: T[]): (val: any) => T[];
+        appendFlipped<T>(list: readonly T[], val: T): T[];
+        appendFlipped<T>(list: readonly T[]): (val: T) => T[];
 
         /**
          * Returns true if the specified value is equal, in R.equals terms,
@@ -1198,10 +1252,10 @@ declare namespace RamdaAdjunct {
          *
          * Like {@link http://ramdajs.com/docs/#contains|R.contains} but with argument order reversed.
          */
-        contained<T>(list: T[], val: T): boolean;
-        contained<T>(list: T[]): (val: T) => boolean;
-        included<T>(list: T[], val: T): boolean; // alias
-        included<T>(list: T[]): (val: T) => boolean; // alias
+        contained<T>(list: readonly T[], val: T): boolean;
+        contained<T>(list: readonly T[]): (val: T) => boolean;
+        included<T>(list: readonly T[], val: T): boolean; // alias
+        included<T>(list: readonly T[]): (val: T) => boolean; // alias
 
         /**
          * Can be used as a way to compose multiple invokers together to form polymorphic functions,
@@ -1213,7 +1267,7 @@ declare namespace RamdaAdjunct {
          * each dispatching function is applied to those same arguments until one of the
          * dispatching functions returns a non-nil value.
          */
-        dispatch(functions: Function[]): Function;
+        dispatch(functions: readonly Function[]): Function;
 
         /**
          * Returns a new list with the item at the position `fromIdx` moved to the position `toIdx`.
@@ -1221,11 +1275,11 @@ declare namespace RamdaAdjunct {
          * of the `list`. When negative indices are provided, the behavior of the move is
          * unspecified.
          */
-        move<T>(fromIdx: number, toIdx: number, list: T[]): T[];
-        move<T>(fromIdx: number): (toIdx: number, list: T[]) => T[];
-        move<T>(fromIdx: number): {
-            (toIdx: number, list: T[]): T[];
-            (toIdx: number): (list: T[]) => T[];
+        move<T>(fromIdx: number, toIdx: number, list: readonly T[]): T[];
+        move(fromIdx: number): <T>(toIdx: number, list: readonly T[]) => T[];
+        move(fromIdx: number): {
+            <T>(toIdx: number, list: readonly T[]): T[];
+            (toIdx: number): <T>(list: readonly T[]) => T[];
         };
 
         /**
@@ -1301,17 +1355,18 @@ declare namespace RamdaAdjunct {
         /**
          * Converts value to an array.
          */
-        toArray<T>(iterable: Iterable<T> | T): any[];
+        toArray<T>(iterable: ArrayLike<T> | Iterable<T>): T[];
+        toArray<T extends Dictionary>(iterable: T): ValueOf<T>[];
 
         /**
          * Returns true if all items in the list are unique. `R.equals` is used to determine equality.
          */
-        allUnique<T>(list: T[]): boolean;
+        allUnique(list: readonly unknown[]): boolean;
 
         /**
          * Returns true if at least one item of the list is repeated. `R.equals` is used to determine equality.
          */
-        notAllUnique<T>(list: T[]): boolean;
+        notAllUnique(list: readonly unknown[]): boolean;
 
         /**
          * Removes whitespace from the beginning of a string
@@ -1372,26 +1427,21 @@ declare namespace RamdaAdjunct {
         /**
          * Sort a list of objects by a list of props (if first prop value is equivalent, sort by second, etc).
          */
-        sortByProps(props: string[], list: object[]): object[];
-        sortByProps(props: string[]): (list: object[]) => object[];
+        sortByProps<T extends Dictionary, U extends keyof T>(props: readonly U[], list: readonly T[]): T[];
+        sortByProps(props: readonly KeyTypes[]): <T extends Dictionary>(list: readonly T[]) => T[];
 
         /**
          * When given a number n and an array, returns an array containing every nth element.
          */
-        skipTake<T>(n: number, list: T[]): T[];
-        skipTake<T>(n: number): (list: T[]) => T[];
-
-        /**
-         * Determine if input value is an indexed data type.
-         */
-        isIndexed(val: any): val is string | any[];
+        skipTake<T>(n: number, list: readonly T[]): T[];
+        skipTake(n: number): <T>(list: readonly T[]) => T[];
 
         /**
          * Invokes the method at path of object with given arguments.
          */
-        invokeArgs(pathToMethod: string[], args: Array<string | number>, obj: object): any;
-        invokeArgs(pathToMethod: string[], args: Array<string | number>): (obj: object) => any;
-        invokeArgs(pathToMethod: string[]): (args: Array<string | number>, obj: object) => any;
+        invokeArgs(pathToMethod: readonly string[], args: readonly unknown[], obj: object): unknown;
+        invokeArgs(pathToMethod: readonly string[], args: readonly unknown[]): (obj: object) => unknown;
+        invokeArgs(pathToMethod: readonly string[]): (args: readonly unknown[], obj: object) => unknown;
 
         /**
          * Converts double-precision 64-bit binary format IEEE 754 to signed 32 bit integer number.

--- a/types/test/argsPass.ts
+++ b/types/test/argsPass.ts
@@ -4,7 +4,7 @@ import * as RA from 'ramda-adjunct';
  * Helpers.
  */
 
-const combiningPredicate = <T>(predicateFn: Function) => (iterable: T[]): boolean =>
+const combiningPredicate = <T>(predicateFn: Function) => (iterable: readonly T[]): boolean =>
     iterable.reduce((acc: boolean, val: T) => acc && predicateFn(val), true);
 
 const nonBoolPredicate = (val: string): string => val;

--- a/types/test/invokeArgs.ts
+++ b/types/test/invokeArgs.ts
@@ -1,7 +1,8 @@
 import * as RA from 'ramda-adjunct';
 
-RA.invokeArgs(['abs'], [-1], Math); // $ExpectType any
-RA.invokeArgs(['nonexistentMethod'], [-1], Math); // $ExpectType any
+RA.invokeArgs(['abs'], [-1], Math); // $ExpectType unknown
+RA.invokeArgs(['nonexistentMethod'], [-1], Math); // $ExpectType unknown
+
 RA.invokeArgs([0, 'a'], [-1], Math); // $ExpectError
 RA.invokeArgs([{}], [-1], Math); // $ExpectError
 RA.invokeArgs([0], {}, Math); // $ExpectError

--- a/types/test/pathOrLazy.ts
+++ b/types/test/pathOrLazy.ts
@@ -1,6 +1,6 @@
 import * as RA from 'ramda-adjunct';
 
-RA.pathOrLazy(() => 7, ['a', 1, 'b'], {}); // $ExpectType number
-RA.pathOrLazy(() => 7, ['a', 1, 'b'])({}); // $ExpectType number
-RA.pathOrLazy(() => 7)(['a', 1, 'b'], {}); // $ExpectType number
-RA.pathOrLazy(() => 7)(['a', 1, 'b'])({}); // $ExpectType number
+RA.pathOrLazy(() => 7, ['a', 1, 'b'], {}); // $ExpectType unknown
+RA.pathOrLazy(() => 7, ['a', 1, 'b'])({}); // $ExpectType unknown
+RA.pathOrLazy(() => 7)(['a', 1, 'b'], {}); // $ExpectType unknown
+RA.pathOrLazy(() => 7)(['a', 1, 'b'])({}); // $ExpectType unknown

--- a/types/test/skipTake.ts
+++ b/types/test/skipTake.ts
@@ -1,8 +1,8 @@
 import * as RA from 'ramda-adjunct';
 
 RA.skipTake(2, [1, 2, 3, 4]); // $ExpectType number[]
-RA.skipTake<number>(2)([1, 2, 3, 4]); // $ExpectType number[]
-RA.skipTake<number>(2)([1, 2, 3, 4]); // $ExpectType number[]
+RA.skipTake(2)([1, 2, 3, 4]); // $ExpectType number[]
+RA.skipTake(2)([1, 2, 3, 4]); // $ExpectType number[]
 
 RA.skipTake(0, 'asd'); // $ExpectError
 RA.skipTake('12', []); // $ExpectError

--- a/types/test/sortByProps.ts
+++ b/types/test/sortByProps.ts
@@ -15,12 +15,19 @@ const clara = {
   age: 314.159,
   lastName: 'Kris',
 };
-const people = [clara, bob, alice];
+const immutablePeople = [clara, bob, alice] as const;
+const mutablePeople = [clara, bob];
+const immutableProps = ['lastName', 'name'] as const;
+const mutableProps = ['age'];
 
-RA.sortByProps(['name'])(people); // $ExpectType object[]
-RA.sortByProps(['p'])(people); // $ExpectType object[]
-RA.sortByProps(['lastName', 'name'])(people); // $ExpectType object[]
-RA.sortByProps(['lastName', 'p', 'name'])(people); // $ExpectType object[]
+// tslint:disable:max-line-length
+RA.sortByProps(mutableProps)(immutablePeople); // $ExpectType ({ name: string; age: number; lastName: string; } | { name: string; age: number; lastName: string; } | { name: string; age: number; lastName: string; })[]
+RA.sortByProps(['p'])(immutablePeople); // $ExpectType ({ name: string; age: number; lastName: string; } | { name: string; age: number; lastName: string; } | { name: string; age: number; lastName: string; })[]
+RA.sortByProps(immutableProps, immutablePeople); // $ExpectType ({ name: string; age: number; lastName: string; } | { name: string; age: number; lastName: string; } | { name: string; age: number; lastName: string; })[]
+RA.sortByProps(immutableProps)(mutablePeople); // $ExpectType { name: string; age: number; lastName: string; }[]
+RA.sortByProps(mutableProps)(mutablePeople); // $ExpectType { name: string; age: number; lastName: string; }[]
+// tslint:enable:max-line-length
 
 RA.sortByProps(['name'])(123); // $ExpectError
-RA.sortByProps(123)(people); // $ExpectError
+RA.sortByProps(['lastName', 'p', 'name'], mutablePeople); // $ExpectError
+RA.sortByProps(123)(immutablePeople); // $ExpectError

--- a/types/test/toArray.ts
+++ b/types/test/toArray.ts
@@ -1,7 +1,11 @@
 import * as RA from 'ramda-adjunct';
 
-RA.toArray([1, 2, 3]); // $ExpectType any[]
-RA.toArray(null); // $ExpectType any[]
-RA.toArray(undefined); // $ExpectType any[]
-RA.toArray(1); // $ExpectType any[]
-RA.toArray({}); // $ExpectType any[]
+RA.toArray('1'); // $ExpectType string[]
+RA.toArray([1, 2, 3]); // $ExpectType number[]
+RA.toArray({ a: 1, b: 2 }); // $ExpectType number[]
+RA.toArray({ c: 0, d: 'd' }); // $ExpectType (string | number)[]
+RA.toArray({}); // $ExpectType never[]
+
+RA.toArray(null); // $ExpectError
+RA.toArray(undefined); // $ExpectError
+RA.toArray(1); // $ExpectError

--- a/types/test/unzipObjWith.ts
+++ b/types/test/unzipObjWith.ts
@@ -1,11 +1,11 @@
 import * as RA from 'ramda-adjunct';
 
-RA.unzipObjWith((v, k) => [k, 1], { a: 1 }); // $ExpectType [string[], number[]]
-RA.unzipObjWith((v, k) => [2, 'hello'])({ a: 1 }); // $ExpectType [number[], string[]]
-RA.unzipObjWith((v, k) => [k, 1], {}); // $ExpectType [string[], number[]]
-RA.unzipObjWith<string, boolean, number>((v, k) => [true, 5], { a: 'b' }); // $ExpectType [boolean[], number[]]
+RA.unzipObjWith((_, k) => [k, 1], { a: 1 }); // $ExpectType ["a"[], number[]]
+RA.unzipObjWith(() => [2, 'hello'])({ a: 1 }); // $ExpectType [number[], string[]]
+RA.unzipObjWith((_, k) => [k, 1], {}); // $ExpectType [never[], number[]]
+RA.unzipObjWith(() => [true, 5], { a: 'b' }); // $ExpectType [boolean[], number[]]
+RA.unzipObjWith((v, k) => [k, v], { a: 'b' }); // $ExpectType ["a"[], string[]]
 
-RA.unzipObjWith((v, k) => true, { a: 1 }); // $ExpectError
+RA.unzipObjWith(() => true, { a: 1 }); // $ExpectError
 RA.unzipObjWith((v, k) => [k, v], []); // $ExpectError
-RA.unzipObjWith<string, boolean, number>((v, k) => [k, v], { a: 'b' }); // $ExpectError
 RA.unzipObjWith((v, k) => [k, v], undefined); // $ExpectError

--- a/types/test/zipObjWith.ts
+++ b/types/test/zipObjWith.ts
@@ -1,10 +1,9 @@
 import * as RA from 'ramda-adjunct';
 
-RA.zipObjWith((v, t) => [t, 1], ['a'], [2]); // $ExpectType { [k: string]: number; }
-RA.zipObjWith((v, k) => ['a', 'b'])([1], ['b']); // $ExpectType { [k: string]: string; }
-RA.zipObjWith<string, boolean, number>((v, k) => ['a', 1], [true], ['b']); // $ExpectType { [k: string]: number; }
+RA.zipObjWith((_, k) => [k, 1], ['a'], [2]); // $ExpectType Record<string | number | symbol, unknown>
+RA.zipObjWith(() => ['a', 'b'])([1], ['b']); // $ExpectType Record<string | number | symbol, unknown>
 
-RA.zipObjWith((v, k) => true, ['a'], [2]); // $ExpectError
+RA.zipObjWith(() => true, ['a'], [2]); // $ExpectError
 RA.zipObjWith((v, k) => [k, v], {}, false); // $ExpectError
-RA.zipObjWith<boolean, boolean, string>((v, k) => ['a', 1], [true], ['b']); // $ExpectError
+RA.zipObjWith(() => ['a', 1], [true], ['b']); // $ExpectError
 RA.zipObjWith((v, k) => [k, v], undefined, undefined); // $ExpectError

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,26 +1,69 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "dtslint/dtslint.json"
+  "defaultSeverity": "error",
+  "extends": [
+    "dtslint/dtslint.json"
+  ],
+  "jsRules": {},
+  "rules": {
+    "array-type": [
+      true,
+      "array"
     ],
-    "jsRules": {},
-    "rules": {
-      "prefer-readonly": [false],
-      "await-promise": [false],
-      "no-for-in-array": [false],
-      "no-void-expression": [false],
-      "use-default-type-parameter": [false],
-      "no-boolean-literal-compare": [false],
-      "no-unnecessary-qualifier": [false],
-      "no-unnecessary-type-assertion": [false],
-      "no-import-default-of-export-equals": [false],
-      "no-relative-import-in-test": [false],
-      "no-unnecessary-generics": [false],
-      "strict-export-declare-modifiers": [false],
-      "interface-name": [true, "never-prefix"],
-      "ban-types": [true, ["Object", "Use {} instead."], ["String"], ["Number"]],
-      "member-ordering": false,
-      "no-namespace": false
-    },
-    "rulesDirectory": []
+    "prefer-readonly": [
+      false
+    ],
+    "await-promise": [
+      false
+    ],
+    "no-for-in-array": [
+      false
+    ],
+    "no-void-expression": [
+      false
+    ],
+    "use-default-type-parameter": [
+      false
+    ],
+    "no-boolean-literal-compare": [
+      false
+    ],
+    "no-unnecessary-qualifier": [
+      false
+    ],
+    "no-unnecessary-type-assertion": [
+      false
+    ],
+    "no-import-default-of-export-equals": [
+      false
+    ],
+    "no-relative-import-in-test": [
+      false
+    ],
+    "no-unnecessary-generics": [
+      false
+    ],
+    "strict-export-declare-modifiers": [
+      false
+    ],
+    "interface-name": [
+      true,
+      "never-prefix"
+    ],
+    "ban-types": [
+      true,
+      [
+        "Object",
+        "Use {} instead."
+      ],
+      [
+        "String"
+      ],
+      [
+        "Number"
+      ]
+    ],
+    "member-ordering": false,
+    "no-namespace": false
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
Firstly, I want to say thanks for this amazing project.

I just started to use it in a new project that uses TS and as I found some unexpected behaviors in type definitions, I'm sending this PR in hope to fix them :). 

- I had to update the types to 3.5 due to the utility types I used (`Exclude`, `Extract`, `Omit`, etc.), but I guess it's fine since this version has landed a year ago. In any case, let me know if it's the right thing to do.
- While I noticed that there are many type definitions that doesn't have test files, I preferred to not create them in this PR or it'd be a pain to review. If you agree, I could send smaller PRs later.
- `tslint.json`'s changes are basically formatting changes made by `prettier`.
- This PR includes support for readonly array and _tries_ to infer the types more concisely.

<hr>

Let me know if this PR is too big to review so I can split this as you like.