### PR TITLE
Fix compact type for objects

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1184,10 +1184,11 @@ declare namespace RamdaAdjunct {
         dropArgs(fn: Function): Function;
 
         /**
-         * Creates an array with all falsy values removed.
+         * Creates an array or an object with all falsy values removed.
          * The values false, null, 0, "", undefined, and NaN are falsy.
          */
         compact<T>(list: T[]): Array<NonNullable<T>>;
+        compact<T>(record: Dictionary<T>): Dictionary<NonNullable<T>>;
 
         /**
          * Returns a new list containing the contents of the given list, followed by the given


### PR DESCRIPTION
Hi, 
For now when you pass an object to compact function there is a type problem event if everything is good.

This PR fix this behaviour.

This PR fix another issue with compact, so I didn't do anything which could collide with it. 
https://github.com/char0n/ramda-adjunct/pull/1603