### PR TITLE
Add renameKeyWith

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,7 @@ export { default as invokeArgs } from './invokeArgs';
 export { default as paths } from './paths';
 export { default as renameKeys } from './renameKeys';
 export { default as renameKeysWith } from './renameKeysWith';
+export { default as renameKeyWith } from './renameKeyWith';
 export { default as mergeRight } from './mergeRight';
 export { default as mergeLeft } from './mergeRight';
 export { default as resetToDefault } from './mergeRight';

--- a/src/renameKeyWith.js
+++ b/src/renameKeyWith.js
@@ -1,13 +1,13 @@
-import { curry, isNil, omit, pick } from 'ramda';
+import { curry, equals, when } from 'ramda';
 
 import renameKeysWith from './renameKeysWith';
-import mergeRight from './mergeRight';
 
 /**
  * Creates a new object with the own properties of the provided object, but the
  * key `key` renamed according to logic of renaming function.
  *
- * If the new key name already existed in the object, it will be overwritten.
+ * Keep in mind that in case the new key name already existed on the object,
+ * the behaviour is undefined and the result may vary between various JS engines!
  *
  * @func renameKeyWith
  * @memberOf RA
@@ -24,9 +24,7 @@ import mergeRight from './mergeRight';
  * RA.renameKeyWith(R.concat('a'), 'A', { A: 1 }) //=> { aA: 1 }
  */
 const renameKeyWith = curry((fn, key, obj) =>
-  isNil(obj)
-    ? {}
-    : mergeRight(renameKeysWith(fn, pick(key, obj)), omit(key, obj))
+  renameKeysWith(when(equals(key), fn), obj)
 );
 
 export default renameKeyWith;

--- a/src/renameKeyWith.js
+++ b/src/renameKeyWith.js
@@ -13,7 +13,7 @@ import renameKeysWith from './renameKeysWith';
  * @memberOf RA
  * @since {@link https://char0n.github.io/ramda-adjunct/2.29.0|v2.29.0}
  * @category Object
- * @sig (k -> k) -> k -> {k: v} -> {k: v
+ * @sig (k -> k) -> k -> {k: v} -> {k: v}
  * @param {Function} fn Function that renames the keys
  * @param {!string} key Key to rename
  * @param {!Object} obj Provided object

--- a/src/renameKeyWith.js
+++ b/src/renameKeyWith.js
@@ -1,0 +1,33 @@
+import { curry, isNil, omit, pick } from 'ramda';
+
+import renameKeysWith from './renameKeysWith';
+import mergeRight from './mergeRight';
+
+/**
+ * Creates a new object with the own properties of the provided object, but the
+ * key `key` renamed according to logic of renaming function.
+ *
+ * Keep in mind that in the case of keys conflict is behaviour undefined and
+ * the result may vary between various JS engines!
+ *
+ * @func renameKeyWith
+ * @memberOf RA
+ * @since {@link https://char0n.github.io/ramda-adjunct/1.5.0|v1.5.0}
+ * @category Object
+ * @sig (a -> b) -> c -> {a: *} -> {b: *}
+ * @param {Function} fn Function that renames the keys
+ * @param {!string} key Key to rename
+ * @param {!Object} obj Provided object
+ * @return {!Object} New object with renamed key
+ * @see {@link RA.renameKeysWith|renameKeysWith}
+ * @example
+ *
+ * RA.renameKeyWith(R.concat('a'), 'A', { A: 1 }) //=> { aA: 1 }
+ */
+const renameKeyWith = curry((fn, key, obj) =>
+  isNil(obj)
+    ? {}
+    : mergeRight(renameKeysWith(fn, pick(key, obj)), omit(key, obj))
+);
+
+export default renameKeyWith;

--- a/src/renameKeyWith.js
+++ b/src/renameKeyWith.js
@@ -11,9 +11,9 @@ import renameKeysWith from './renameKeysWith';
  *
  * @func renameKeyWith
  * @memberOf RA
- * @since {@link https://char0n.github.io/ramda-adjunct/1.5.0|v1.5.0}
+ * @since {@link https://char0n.github.io/ramda-adjunct/2.29.0|v2.29.0}
  * @category Object
- * @sig (a -> b) -> c -> {a: *} -> {b: *}
+ * @sig (k -> k) -> k -> {k: v} -> {k: v
  * @param {Function} fn Function that renames the keys
  * @param {!string} key Key to rename
  * @param {!Object} obj Provided object

--- a/src/renameKeyWith.js
+++ b/src/renameKeyWith.js
@@ -7,8 +7,7 @@ import mergeRight from './mergeRight';
  * Creates a new object with the own properties of the provided object, but the
  * key `key` renamed according to logic of renaming function.
  *
- * Keep in mind that in the case of keys conflict is behaviour undefined and
- * the result may vary between various JS engines!
+ * If the new key name already existed in the object, it will be overwritten.
  *
  * @func renameKeyWith
  * @memberOf RA

--- a/test/renameKeyWith.js
+++ b/test/renameKeyWith.js
@@ -1,0 +1,23 @@
+import { assert } from 'chai';
+import { concat } from 'ramda';
+
+import * as RA from '../src';
+
+describe('renameKeyWith', function () {
+  it('should rename object keys', function () {
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', { A: 1 }), {
+      aA: 1,
+    });
+  });
+
+  it('should return an empty object when renames keys on null and undefined', function () {
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', null), {});
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', undefined), {});
+  });
+
+  it('should be curried', function () {
+    assert.deepEqual(RA.renameKeyWith(concat('a'))('A')({ A: 1 }), {
+      aA: 1,
+    });
+  });
+});

--- a/test/renameKeyWith.js
+++ b/test/renameKeyWith.js
@@ -15,6 +15,12 @@ describe('renameKeyWith', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', undefined), {});
   });
 
+  it('should overwrite existing values for the new key name', function () {
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', { A: 1, aA: 2 }), {
+      aA: 1,
+    });
+  });
+
   it('should be curried', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'))('A')({ A: 1 }), {
       aA: 1,

--- a/test/renameKeyWith.js
+++ b/test/renameKeyWith.js
@@ -22,6 +22,12 @@ describe('renameKeyWith', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', undefined), {});
   });
 
+  it('should return the original object when renaming a non-existant key', function () {
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'B', { A: 1 }), {
+      A: 1,
+    });
+  });
+
   it('should be curried', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'))('A')({ A: 1 }), {
       aA: 1,

--- a/test/renameKeyWith.js
+++ b/test/renameKeyWith.js
@@ -22,12 +22,6 @@ describe('renameKeyWith', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', undefined), {});
   });
 
-  it('should overwrite existing values for the new key name', function () {
-    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', { A: 1, aA: 2 }), {
-      aA: 1,
-    });
-  });
-
   it('should be curried', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'))('A')({ A: 1 }), {
       aA: 1,

--- a/test/renameKeyWith.js
+++ b/test/renameKeyWith.js
@@ -10,6 +10,13 @@ describe('renameKeyWith', function () {
     });
   });
 
+  it('should not change other key-value pairs', function () {
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', { A: 1, B: 2 }), {
+      aA: 1,
+      B: 2,
+    });
+  });
+
   it('should return an empty object when renames keys on null and undefined', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', null), {});
     assert.deepEqual(RA.renameKeyWith(concat('a'), 'A', undefined), {});

--- a/test/renameKeyWith.js
+++ b/test/renameKeyWith.js
@@ -26,5 +26,11 @@ describe('renameKeyWith', function () {
     assert.deepEqual(RA.renameKeyWith(concat('a'))('A')({ A: 1 }), {
       aA: 1,
     });
+    assert.deepEqual(RA.renameKeyWith(concat('a'), 'A')({ A: 1 }), {
+      aA: 1,
+    });
+    assert.deepEqual(RA.renameKeyWith(concat('a'))('A', { A: 1 }), {
+      aA: 1,
+    });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -562,6 +562,26 @@ declare namespace RamdaAdjunct {
         renameKeysWith(renameFn: (key: string) => string): (obj: object) => object;
 
         /**
+         * Creates a new object with the own properties of the provided object, but the
+         * key `key` renamed according to logic of renaming function.
+         */
+        renameKeyWith(
+            renameFn: (key: string) => string,
+            key: string,
+            obj: object
+        ): object;
+        renameKeyWith(
+            renameFn: (key: string) => string,
+            key: string
+        ): (obj: object) => object;
+        renameKeyWith(
+            renameFn: (key: string) => string
+        ): {
+            (key: string, obj: object): object;
+            (key: string): (obj: object) => object;
+        };
+
+        /**
          * Create a new object with the own properties of the second object merged with
          * the own properties of the first object. If a key exists in both objects,
          * the value from the first object will be used. *

--- a/types/test/renameKeyWith.ts
+++ b/types/test/renameKeyWith.ts
@@ -1,0 +1,6 @@
+import * as RA from 'ramda-adjunct';
+
+RA.renameKeyWith((str) => 'a' + str, 'A', { A: 1 }); // $ExpectType object
+RA.renameKeyWith((str) => 'a' + str)('A', { A: 1 }); // $ExpectType object
+RA.renameKeyWith((str) => 'a' + str)('A')({ A: 1 }); // $ExpectType object
+RA.renameKeyWith((str) => 'a' + str, 'A')({ A: 1 }); // $ExpectType object

--- a/types/test/renameKeyWith.ts
+++ b/types/test/renameKeyWith.ts
@@ -4,3 +4,7 @@ RA.renameKeyWith((str) => 'a' + str, 'A', { A: 1 }); // $ExpectType object
 RA.renameKeyWith((str) => 'a' + str)('A', { A: 1 }); // $ExpectType object
 RA.renameKeyWith((str) => 'a' + str)('A')({ A: 1 }); // $ExpectType object
 RA.renameKeyWith((str) => 'a' + str, 'A')({ A: 1 }); // $ExpectType object
+
+RA.renameKeyWith((str) => 1, 'A', { A: 1 }); // $ExpectError
+RA.renameKeyWith((str) => 'a' + str, 1, { A: 1 }); // $ExpectError
+RA.renameKeyWith((str) => 'a' + str, 'A', 1); // $ExpectError


### PR DESCRIPTION
Closes #1228

Hi there! Some questions:

1. I'm not sure I got the signature in the documentation correct, could you please check it? Currently it is `(a -> b) -> c -> {a: *} -> {b: *}`
2. I did two versions, one is a bit simpler (the latest commit), but the other one (before the latest commit) has the advantage of being stable when changing to an existing key name. Which one do you prefer?
3. For typing I just went with `object` as it is used for `renameKeysWith`, but actually I would prefer to limit the input to a `Record` and then limit the key to be a key of said record. The more complicated version has the disadvantage that it relies on `mergeRight` which we would have to use from `ramda-adjunct` even though it is deprecated to keep compatibilty with older `ramda` versions that do not include `mergeRight` yet. What do you think?

PS: There is no mention that PhantomJS is needed to run tests locally. I could either add it as devDependency or to the documentation in a separate PR if you want.