### PR TITLE
Add missing type tests

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -542,8 +542,8 @@ declare namespace RamdaAdjunct {
             (either: Catamorphism<V1 | V2>,
             ) => T1 | T2;
         cata<V1, V2, T1, T2>(leftFn: (leftValue: V1) => T1): {
-            (rightFn: (rightValue: V2) => T1, either: Catamorphism<V1 | V2>): T1 | T2;
-            (rightFn: (rightValue: V2) => T1): (either: Catamorphism<V1 | V2>) => T1 | T2
+            (rightFn: (rightValue: V2) => T2, either: Catamorphism<V1 | V2>): T1 | T2;
+            (rightFn: (rightValue: V2) => T2): (either: Catamorphism<V1 | V2>) => T1 | T2
         };
 
         /**

--- a/types/test/async.ts
+++ b/types/test/async.ts
@@ -1,0 +1,6 @@
+import * as RA from 'ramda-adjunct';
+
+RA.async(() => {}); // $ExpectType Function
+RA.async(1); // $ExpectError
+RA.async(''); // $ExpectError
+RA.async({}); // $ExpectError

--- a/types/test/cata.ts
+++ b/types/test/cata.ts
@@ -1,0 +1,26 @@
+import * as RA from 'ramda-adjunct';
+
+const result1 = RA.cata(
+  () => 1,
+  () => true,
+  { cata: () => '' }
+);
+result1; // $ExpectType number | boolean
+
+const result2 = RA.cata(
+  () => 1,
+  () => true
+)({ cata: () => '' });
+result2; // $ExpectType number | boolean
+
+const result3 = RA.cata<string, string, number, boolean>(() => 1)(() => true, {
+  cata: () => '',
+});
+result3; // $ExpectType number | boolean
+
+const result4 = RA.cata<string, string, number, boolean>(() => 1)(() => true)({
+  cata: () => '',
+});
+result4; // $ExpectType number | boolean
+
+RA.cata(1, true, {}); // $ExpectError

--- a/types/test/compact.ts
+++ b/types/test/compact.ts
@@ -1,0 +1,8 @@
+import * as RA from 'ramda-adjunct';
+
+const arr: number[] = RA.compact([1, 2, 3, null]);
+arr; // $ExpectType number[]
+
+RA.compact(1); // $ExpectError
+RA.compact(''); // $ExpectError
+RA.compact({}); // $ExpectError

--- a/types/test/concatAll.ts
+++ b/types/test/concatAll.ts
@@ -1,0 +1,8 @@
+import * as RA from 'ramda-adjunct';
+
+RA.concatAll([[1], [2], [3]]); // $ExpectType number[] | undefined
+RA.concatAll([]); // $ExpectType undefined
+
+RA.concatAll(1); // $ExpectError
+RA.concatAll({}); // $ExpectError
+RA.concatAll([1]); // $ExpectError

--- a/types/test/concatRight.ts
+++ b/types/test/concatRight.ts
@@ -1,0 +1,10 @@
+import * as RA from 'ramda-adjunct';
+
+RA.concatRight('ab', 'cd'); // $ExpectType string
+RA.concatRight('ab')('cd'); // $ExpectType string
+RA.concatRight([1, 2], [3, 4]); // $ExpectType number[]
+RA.concatRight([1, 2])([3, 4]); // $ExpectType number[]
+
+RA.concatRight(1, 2); // $ExpectError
+RA.concatRight({}, {}); // $ExpectError
+RA.concatRight('ab', [1, 2]); // $ExpectError


### PR DESCRIPTION
Progress on #978

With this, all functions alphabetically from `allEqual` to `concatRight` are type tested. This also fixes wrong types for a curried version of `cata`