### PR TITLE
fix Identity missing in documentation

### DIFF
--- a/src/fantasy-land/Identity.js
+++ b/src/fantasy-land/Identity.js
@@ -66,7 +66,6 @@ class Identity {
   /**
    * Private constructor. Use {@link RA.Identity.of|Identity.of} instead.
    *
-   * @private
    * @param {*} value
    * @return {RA.Identity}
    */


### PR DESCRIPTION
Closes #1614

It is now working as expected.
![image](https://user-images.githubusercontent.com/49380551/95342710-4f419680-08ea-11eb-9eb3-f6008b7f5c32.png)

As mentioned in [JSDoc `@private` page](https://jsdoc.app/tags-private.html),
> The `@private` tag marks a symbol as private, or not meant for general use. Private members are not shown in the generated output unless JSDoc is run with the `-p/--private` command-line option. In JSDoc 3.3.0 and later, you can also use the `-a/--access` command-line option to change this behavior.