### PR TITLE
fix(types): remove isNotEmpty type declaration

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,11 +108,6 @@ export function isNonEmptyArray(val: any): val is any[];
 export function isNotBoolean(val: any): boolean;
 
 /**
- * Returns true if the given value is not its type's empty value; `false` otherwise.
- */
-export function isNotEmpty(val: any): boolean;
-
-/**
  * Checks if input value is complement of `null` or `undefined`.
  */
 /* tslint:disable-next-line:no-null-undefined-union null or undefined is the accurate type here */


### PR DESCRIPTION
isNotEmpty was removed in #2983 but this type declaration was not. This results in language servers reporting that isNotEmpty is available when it is not.

Closes #3071