### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "git://github.com/char0n/ramda-adjunct.git"
+    "url": "git+https://github.com/char0n/ramda-adjunct.git"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
## Summary

- replace the legacy `git://` repository URL in `package.json`
- keep the package metadata pointed at this public GitHub repository over HTTPS

## Validation

- `node -e "const pkg=require('./package.json'); if(pkg.repository.url !== 'git+https://github.com/char0n/ramda-adjunct.git') throw new Error(pkg.repository.url)"`
- `node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8'))"`
- `git diff --check`
- `git ls-remote https://github.com/char0n/ramda-adjunct.git HEAD`
