### PR TITLE
Security: Incorrect Fallback Value for Number.MIN_SAFE_INTEGER

### DIFF
--- a/src/internal/ponyfills/Number.MIN_SAFE_INTEGER.js
+++ b/src/internal/ponyfills/Number.MIN_SAFE_INTEGER.js
@@ -1,3 +1,3 @@
-const MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER || -(2 ** 53) - 1;
+const MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER || -(2 ** 53 - 1);
 
 export default MIN_SAFE_INTEGER;


### PR DESCRIPTION
## Summary

Security: Incorrect Fallback Value for Number.MIN_SAFE_INTEGER

## Problem

**Severity**: `Medium` | **File**: `src/internal/ponyfills/Number.MIN_SAFE_INTEGER.js:L1`

The fallback value for `Number.MIN_SAFE_INTEGER` is calculated as `-(2 ** 53) - 1`, which evaluates to `-9007199254740993`. However, the correct value for `Number.MIN_SAFE_INTEGER` is `-9007199254740992` (i.e., `-(2 ** 53) + 1` or `-(2 ** 53 - 1)`). This off-by-one error results in an incorrect constant being used in environments where `Number.MIN_SAFE_INTEGER` is not natively defined.

## Solution

Fix the fallback calculation to `-(2 ** 53 - 1)` or `-(2 ** 53) + 1` to ensure the correct value for `Number.MIN_SAFE_INTEGER` is used.

## Changes

- `src/internal/ponyfills/Number.MIN_SAFE_INTEGER.js` (modified)